### PR TITLE
Add Rect extension functions and window panel size adjustments.

### DIFF
--- a/Sources/Support/Rect+UIExtensions.swift
+++ b/Sources/Support/Rect+UIExtensions.swift
@@ -34,3 +34,25 @@ internal extension Rect {
       Rect(x: Double(CW_USEDEFAULT), y: Double(CW_USEDEFAULT),
            width: Double(CW_USEDEFAULT), height: Double(CW_USEDEFAULT))
 }
+
+public extension Rect {
+  init(from: RECT) {
+    self.x = Double(from.left)
+    self.y = Double(from.top)
+    self.width  = Double(from.right - from.left)
+    self.height = Double(from.bottom - from.top)
+  }
+
+  var isAnyPointDefault: Bool {
+    return self.x == Double(CW_USEDEFAULT) || self.y == Double(CW_USEDEFAULT) ||
+           self.width == Double(CW_USEDEFAULT) || 
+           self.height == Double(CW_USEDEFAULT)
+  }
+}
+
+internal extension RECT {
+  init(from: Rect) {
+    self.init(left: Int32(from.x), top: Int32(from.y), right: Int32(from.width),
+              bottom: Int32(from.height))
+  }
+}

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -45,6 +45,11 @@ public class View {
     self.style = style
 
     self.frame = frame
+    if !self.frame.isAnyPointDefault {
+      var r = RECT(from: self.frame);
+      AdjustWindowRect(&r, self.style, false)
+      self.frame = Rect(from: r)
+    }
     self.hWnd =
         CreateWindowExW(0, self.class.name, "".LPCWSTR, self.style,
                         Int32(self.frame.x), Int32(self.frame.y),


### PR DESCRIPTION
## Rect+UIExtensions.swift:
- computed property RECT getter
- RECT setter as asignment operator

## View.swift:
- using Rect extentions call AdjustWindowRect to set window size so that panel is the size of rect excluding the border size.