### PR TITLE
Switch to swift-log for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,13 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(SwiftWin32 LANGUAGES Swift)
 
+option(ENABLE_LOGGING "Enable logging through swift-log" NO)
+
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+if(ENABLE_LOGGING)
+  find_package(swift-log CONFIG QUIET)
+endif()
 
 add_library(SwiftWin32 SHARED
   Sources/Application/Application.swift
@@ -26,6 +32,7 @@ target_sources(SwiftWin32 PRIVATE
   Sources/CG/Rect.swift
   Sources/CG/Size.swift)
 target_sources(SwiftWin32 PRIVATE
+  Sources/Support/Logging.swift
   Sources/Support/Range.swift
   Sources/Support/Rect+UIExtensions.swift
   Sources/Support/String.swift
@@ -33,6 +40,14 @@ target_sources(SwiftWin32 PRIVATE
 target_compile_options(SwiftWin32 PRIVATE
   -Xcc -DCOBJMACROS)
 target_link_libraries(SwiftWin32 PUBLIC User32 Gdi32 ComCtl32)
+if(ENABLE_LOGGING)
+  target_compile_definitions(SwiftWin32 PRIVATE
+    ENABLE_LOGGING)
+  if(TARGET SwiftLog::Logging)
+    target_link_libraries(SwiftWin32 PUBLIC
+      SwiftLog::Logging)
+  endif()
+endif()
 set_target_properties(SwiftWin32 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY}
   INTERFACE_LINK_DIRECTORIES $<TARGET_LINKER_FILE_DIR:SwiftWin32>)

--- a/Sources/Support/Logging.swift
+++ b/Sources/Support/Logging.swift
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#if ENABLE_LOGGING
+import Logging
+
+internal let log: Logger = Logger(label: "org.compnerd.swift-win32")
+#endif

--- a/Sources/UI/Font.swift
+++ b/Sources/UI/Font.swift
@@ -64,8 +64,12 @@ public class Font {
 
   public var fontName: String {
     var lfFont: LOGFONTW = LOGFONTW()
-    if GetObjectW(self.hFont.value, Int32(MemoryLayout<LOGFONTW>.size), &lfFont) == 0 {
-      print("GetObjectW: \(GetLastError())")
+
+    if GetObjectW(self.hFont.value, Int32(MemoryLayout<LOGFONTW>.size),
+                  &lfFont) == 0 {
+#if ENABLE_LOGGING
+      log.error("GetObjectW: \(GetLastError())")
+#endif
       return ""
     }
     return withUnsafePointer(to: &lfFont.lfFaceName) {


### PR DESCRIPTION
Switch from the `print` to logging via `swift-log`.  This provides a
much more structured approach to handling errors in the UI framework.