### PR TITLE
UI: generalize the windows handle management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(SwiftWin32 PRIVATE
   Sources/Support/Range.swift
   Sources/Support/Rect+UIExtensions.swift
   Sources/Support/String.swift
+  Sources/Support/WindowsHandle.swift
   Sources/Support/WinSDK+Extensions.swift)
 target_compile_options(SwiftWin32 PRIVATE
   -Xcc -DCOBJMACROS)

--- a/Sources/Support/WindowsHandle.swift
+++ b/Sources/Support/WindowsHandle.swift
@@ -1,0 +1,68 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+internal protocol HandleOperations {
+  static var invalid: Self { get }
+  func release()
+}
+
+internal class ManagedHandle<HandleType: HandleOperations> {
+  private enum ValueType<HandleType> {
+  case owning(HandleType?)
+  case referencing(HandleType?)
+  }
+
+  private var handle: ValueType<HandleType>
+
+  public var value: HandleType? {
+    switch self.handle {
+    case .owning(let handle):
+      return handle
+    case .referencing(let handle):
+      return handle
+    }
+  }
+
+  init(owning handle: HandleType?) {
+    self.handle = .owning(handle)
+  }
+
+  init(referencing handle: HandleType?) {
+    self.handle = .referencing(handle)
+  }
+
+  deinit {
+    switch self.handle {
+    case .owning(let handle):
+      handle?.release()
+    case .referencing(_):
+      break
+    }
+  }
+}

--- a/Sources/UI/Font.swift
+++ b/Sources/UI/Font.swift
@@ -29,30 +29,10 @@
 
 import WinSDK
 
-internal protocol FontHandle {
-  var value: HFONT? { get }
-}
-
-internal class OwningFontHandle: FontHandle {
-  let value: HFONT?
-
-  init(_ hFont: HFONT?) {
-    self.value = hFont
-  }
-
-  deinit {
-    if let hFont = value {
-      DeleteObject(hFont)
-    }
-  }
-}
-
-internal struct UnownedFontHandle: FontHandle {
-  let value: HFONT?
-
-  init(hFont: HFONT?) {
-    self.value = hFont
-  }
+internal typealias FontHandle = ManagedHandle<HFONT>
+extension HFONT: HandleOperations {
+  static var invalid: HFONT { HFONT(bitPattern: 0)! }
+  func release() { DeleteObject(self) }
 }
 
 public class Font {
@@ -68,9 +48,11 @@ public class Font {
       print("GetObjectW: \(GetLastError())")
       return ""
     }
+
     return withUnsafePointer(to: &lfFont.lfFaceName) {
-      return $0.withMemoryRebound(to: UInt16.self,
-                                  capacity: MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size) {
+      let capacity: Int =
+          MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size
+      return $0.withMemoryRebound(to: UInt16.self, capacity: capacity) {
         return String(decodingCString: $0, as: UTF16.self)
       }
     }
@@ -95,8 +77,9 @@ public class Font {
           UnsafeMutablePointer<Set<String>>(bitPattern: Int(lParam))!
 
       let family: String = withUnsafePointer(to: lpelfe?.pointee.lfFaceName) {
-        $0.withMemoryRebound(to: UInt16.self,
-                             capacity: MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size) {
+        let capacity: Int =
+            MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size
+        return $0.withMemoryRebound(to: UInt16.self, capacity: capacity) {
           String(decodingCString: $0, as: UTF16.self)
         }
       }
@@ -122,8 +105,9 @@ public class Font {
           UnsafeMutablePointer<Set<String>>(bitPattern: Int(lpData))!
 
       let font: String = withUnsafePointer(to: lplf?.pointee.lfFaceName) {
-        $0.withMemoryRebound(to: UInt16.self,
-                             capacity: MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size) {
+        let capacity: Int =
+            MemoryLayout.size(ofValue: $0) / MemoryLayout<WCHAR>.size
+        return $0.withMemoryRebound(to: UInt16.self, capacity: capacity) {
           String(decodingCString: $0, as: UTF16.self)
         }
       }
@@ -133,27 +117,28 @@ public class Font {
     }
 
     _ = withUnsafeMutablePointer(to: &arrFonts) {
-      EnumFontsW(hDC, family.LPCWSTR, pfnEnumerateFonts, LPARAM(Int(bitPattern: $0)))
+      EnumFontsW(hDC, family.LPCWSTR, pfnEnumerateFonts,
+                 LPARAM(Int(bitPattern: $0)))
     }
     return Array<String>(arrFonts)
   }
 
   public init?(name: String, size: Float) {
     let szFontSizeEM = -MulDiv(Int32(size), GetDeviceCaps(GetDC(nil), LOGPIXELSY), 72)
-    self.hFont = OwningFontHandle(CreateFontW(szFontSizeEM,
-                                              /*cWidth=*/0,
-                                              /*cEscapement=*/0,
-                                              /*cOrientation=*/0,
-                                              Font.Weight.regular.rawValue,
-                                              /*bItalic=*/DWORD(0),
-                                              /*bUnderline=*/DWORD(0),
-                                              /*bStrikeOut=*/DWORD(0),
-                                              DWORD(DEFAULT_CHARSET),
-                                              DWORD(OUT_DEFAULT_PRECIS),
-                                              DWORD(CLIP_DEFAULT_PRECIS),
-                                              DWORD(DEFAULT_QUALITY),
-                                              DWORD((FF_DONTCARE << 2) | DEFAULT_PITCH),
-                                              name.LPCWSTR))
+    self.hFont = FontHandle(owning: CreateFontW(szFontSizeEM,
+                                                /*cWidth=*/0,
+                                                /*cEscapement=*/0,
+                                                /*cOrientation=*/0,
+                                                Font.Weight.regular.rawValue,
+                                                /*bItalic=*/DWORD(0),
+                                                /*bUnderline=*/DWORD(0),
+                                                /*bStrikeOut=*/DWORD(0),
+                                                DWORD(DEFAULT_CHARSET),
+                                                DWORD(OUT_DEFAULT_PRECIS),
+                                                DWORD(CLIP_DEFAULT_PRECIS),
+                                                DWORD(DEFAULT_QUALITY),
+                                                DWORD((FF_DONTCARE << 2) | DEFAULT_PITCH),
+                                                name.LPCWSTR))
   }
 }
 

--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -37,7 +37,7 @@ public class Label: Control {
   public var font: Font! {
     get {
       let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(UnownedFontHandle(hFont: HFONT(bitPattern: Int(lResult))))
+      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
     }
     set(font) {
       SendMessageW(hWnd, UINT(WM_SETFONT),

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -46,7 +46,7 @@ public class TextField: Control {
   public var font: Font? {
     get {
       let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(UnownedFontHandle(hFont: HFONT(bitPattern: Int(lResult))))
+      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
     }
     set(font) {
       SendMessageW(hWnd, UINT(WM_SETFONT),

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -54,7 +54,7 @@ public class TextView: View {
   public var font: Font? {
     get {
       let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(UnownedFontHandle(hFont: HFONT(bitPattern: Int(lResult))))
+      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
     }
     set(font) {
       SendMessageW(hWnd, UINT(WM_SETFONT),


### PR DESCRIPTION
Create a new `ManagedHandle` type that represents a managed handle.  The
handle is explicitly marked as owning or referencing.  An owning handle
will be deallocated at the end of the lifetime of the object.  The
constructor explicitly indicates whether the type is owned or not.

This management allows for proper handle type specific handling of the
handles that are being trafficked across the C/Swift boundary.