### PR TITLE
Handle: permit multiple managed handle types

### DIFF
--- a/Sources/Support/WindowsHandle.swift
+++ b/Sources/Support/WindowsHandle.swift
@@ -27,12 +27,14 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
-internal protocol HandleOperations {
-  static var invalid: Self { get }
-  func release()
+internal protocol HandleValue {
+  associatedtype HandleType
+  static func release(_: HandleType?)
 }
 
-internal class ManagedHandle<HandleType: HandleOperations> {
+internal class ManagedHandle<Value: HandleValue> {
+  typealias HandleType = Value.HandleType
+
   private enum ValueType<HandleType> {
   case owning(HandleType?)
   case referencing(HandleType?)
@@ -60,7 +62,9 @@ internal class ManagedHandle<HandleType: HandleOperations> {
   deinit {
     switch self.handle {
     case .owning(let handle):
-      handle?.release()
+      if let handle = handle {
+        Value.release(handle)
+      }
     case .referencing(_):
       break
     }

--- a/Sources/UI/Font.swift
+++ b/Sources/UI/Font.swift
@@ -29,11 +29,16 @@
 
 import WinSDK
 
-internal typealias FontHandle = ManagedHandle<HFONT>
-extension HFONT: HandleOperations {
-  static var invalid: HFONT { HFONT(bitPattern: 0)! }
-  func release() { DeleteObject(self) }
+extension HFONT__: HandleValue {
+  typealias HandleType = HFONT
+  internal static func release(_ hFont: HandleType?) {
+    if let hFont = hFont {
+      DeleteObject(hFont)
+    }
+  }
 }
+
+internal typealias FontHandle = ManagedHandle<HFONT__>
 
 public class Font {
   internal var hFont: FontHandle


### PR DESCRIPTION
Force the `HandleValue` conformance and change the generic parameter
for `ManagedHandle` to the `HandleValue`.  This allows multiple managed
handles by avoiding the overlapping conformances for
`UnmanagedMutablePointer`.