### PR TITLE
Application: add some form of application lifecycle notifications

### DIFF
--- a/Examples/HelloSwift.swift
+++ b/Examples/HelloSwift.swift
@@ -109,6 +109,14 @@ deserunt mollit anim id est laborum.\r\n
 
     return true
   }
+
+  func applicationDidBecomeActive(_: Application) {
+    print("Good morning!")
+  }
+
+  func applicationDidEnterBackground(_: Application) {
+    print("Good night!")
+  }
 }
 
 ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil, SwiftApplicationDelegate())

--- a/Sources/Application/Application.swift
+++ b/Sources/Application/Application.swift
@@ -30,10 +30,11 @@
 public class Application {
   public static var shared: Application = Application()
   public var delegate: ApplicationDelegate?
+  public internal(set) var state: Application.State = .active
 }
 
-public extension Application {
-  struct LaunchOptionsKey: Equatable, Hashable, RawRepresentable {
+extension Application {
+  public struct LaunchOptionsKey: Equatable, Hashable, RawRepresentable {
     public typealias RawValue = String
 
     public var rawValue: RawValue
@@ -44,3 +45,13 @@ public extension Application {
   }
 }
 
+extension Application {
+  /// The running states of the application
+  public enum State: Int {
+    /// The application is running in the foreground
+    case active
+    case inactive
+    /// The application is running in the background
+    case background
+  }
+}

--- a/Sources/Application/ApplicationDelegate.swift
+++ b/Sources/Application/ApplicationDelegate.swift
@@ -34,6 +34,13 @@ public protocol ApplicationDelegate: class {
   func application(_ application: Application,
                    didFinishLaunchingWithOptions options: [Application.LaunchOptionsKey:Any]?)
       -> Bool
+
+  // Responding to App Life-Cycle Events
+  func applicationDidBecomeActive(_ application: Application)
+  func applicationWillResignActive(_ application: Application)
+  func applicationDidEnterBackground(_ application: Application)
+  func applicationWillEnterForeground(_ application: Application)
+  func applicationWillTerminate(_ application: Application)
 }
 
 public extension ApplicationDelegate {
@@ -48,3 +55,19 @@ public extension ApplicationDelegate {
   }
 }
 
+public extension ApplicationDelegate {
+  func applicationDidBecomeActive(_: Application) {
+  }
+
+  func applicationWillResignActive(_: Application) {
+  }
+
+  func applicationDidEnterBackground(_: Application) {
+  }
+
+  func applicationWillEnterForeground(_: Application) {
+  }
+
+  func applicationWillTerminate(_: Application) {
+  }
+}


### PR DESCRIPTION
Hook the application window procedure to intercept the `WM_ACTIVATEAPP`
window message.  Use this to identify the state of the application.

Extended `ApplicationDelegate` to permit the application to handle
the event.