### PR TITLE
build: remove Gdi32 linkage

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -4,5 +4,5 @@ add_custom_command(TARGET HelloSwift POST_BUILD
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/$<TARGET_FILE_NAME:HelloSwift>.manifest $<TARGET_FILE_DIR:HelloSwift>)
 target_link_libraries(HelloSwift PRIVATE
-  Gdi32
+  $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   SwiftWin32)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -33,8 +33,8 @@ target_compile_options(SwiftWin32 PRIVATE
   "SHELL:-Xcc -DNONAMELESSUNION"
   "SHELL:-Xcc -DCOBJMACROS")
 target_link_libraries(SwiftWin32 PUBLIC
+  $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   ComCtl32
-  Gdi32
   User32)
 if(ENABLE_LOGGING)
   target_compile_definitions(SwiftWin32 PRIVATE


### PR DESCRIPTION
Rely on autolinking for the GDI32 linkage.  This was improved in the
Swift 5.3 timeframe, so provide a compatibility shim for 5.2.