### PR TITLE
Application: add support for `@main` based entry

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -3,6 +3,9 @@ add_executable(HelloSwift
 add_custom_command(TARGET HelloSwift POST_BUILD
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/$<TARGET_FILE_NAME:HelloSwift>.manifest $<TARGET_FILE_DIR:HelloSwift>)
+# FIXME(SR-12683) `@main` requires `-parse-as-library`
+target_compile_options(HelloSwift PRIVATE
+  -parse-as-library)
 target_link_libraries(HelloSwift PRIVATE
   $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   SwiftWin32)

--- a/Examples/HelloSwift.swift
+++ b/Examples/HelloSwift.swift
@@ -45,7 +45,8 @@ class EventHandler: WindowDelegate {
   }
 }
 
-class SwiftApplicationDelegate: ApplicationDelegate {
+@main
+final class SwiftApplicationDelegate: ApplicationDelegate {
   var window: Window =
       Window(frame: .default, title: "Swift/Win32 Window")
 
@@ -118,5 +119,3 @@ deserunt mollit anim id est laborum.\r\n
     print("Good night!")
   }
 }
-
-ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil, SwiftApplicationDelegate())

--- a/Sources/Application/Application.swift
+++ b/Sources/Application/Application.swift
@@ -27,10 +27,15 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
-public class Application {
+public class Application: _TriviallyConstructible {
   public static var shared: Application = Application()
+
   public var delegate: ApplicationDelegate?
-  public internal(set) var state: Application.State = .active
+  public internal(set) var state: Application.State
+
+  public required init() {
+    self.state = .active
+  }
 }
 
 extension Application {

--- a/Sources/Application/ApplicationDelegate.swift
+++ b/Sources/Application/ApplicationDelegate.swift
@@ -27,7 +27,11 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
-public protocol ApplicationDelegate: class {
+public protocol _TriviallyConstructible {
+  init()
+}
+
+public protocol ApplicationDelegate: class, _TriviallyConstructible {
   @available(*, deprecated)
   func applicationDidFinishLaunching(_: Application) -> Bool
 
@@ -69,5 +73,12 @@ public extension ApplicationDelegate {
   }
 
   func applicationWillTerminate(_: Application) {
+  }
+}
+
+extension ApplicationDelegate {
+  public static func main() {
+    ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil,
+                    String(describing: String(reflecting: Self.self)))
   }
 }

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -60,15 +60,21 @@ private let pApplicationWindowProc: HOOKPROC = { (nCode: Int32, wParam: WPARAM, 
   return CallNextHookEx(nil, nCode, wParam, lParam)
 }
 
+private func NSClassFromString(_ string: String) -> AnyClass? {
+  return _typeByName(string) as? AnyClass
+}
+
 @discardableResult
 public func ApplicationMain(_ argc: Int32,
                             _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>,
-                            _ application: Application?,
-                            _ delegate: ApplicationDelegate?) -> Int32 {
+                            _ application: String?,
+                            _ delegate: String?) -> Int32 {
   if let application = application {
-    Application.shared = application
+    Application.shared =
+        (NSClassFromString(application)! as! Application.Type).init()
   }
-  Application.shared.delegate = delegate
+  Application.shared.delegate =
+      (NSClassFromString(delegate!)! as! ApplicationDelegate.Type).init()
 
   // Enable Per Monitor DPI Awareness
   if !SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) {


### PR DESCRIPTION
Make the `ApplicationMain(_:_:_:_:)` signature match the original
desired state.  Applications can now mark the `ApplicationDelegate` as
`@main` have the entry point be synthesized.