### PR TITLE
Support: use `OutputDebugStringW` if swift-log is unavailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,14 @@ project(SwiftWin32
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
-option(ENABLE_LOGGING "Enable logging through swift-log" NO)
+option(WITH_SWIFT_LOG "Enable logging through swift-log" NO)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-if(ENABLE_LOGGING)
+if(WITH_SWIFT_LOG)
   find_package(swift-log CONFIG QUIET)
 endif()
 

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -78,9 +78,7 @@ public func ApplicationMain(_ argc: Int32,
 
   // Enable Per Monitor DPI Awareness
   if !SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) {
-#if ENABLE_LOGGING
     log.error("SetProcessDpiAwarenessContext: \(GetLastError())")
-#endif
   }
 
   var ICCE: INITCOMMONCONTROLSEX =
@@ -91,17 +89,13 @@ public func ApplicationMain(_ argc: Int32,
   var hSwiftWin32: HMODULE?
   if !GetModuleHandleExW(DWORD(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT),
                                "SwiftWin32.dll".LPCWSTR, &hSwiftWin32) {
-#if ENABLE_LOGGING
     log.error("GetModuleHandleExW: \(GetLastError())")
-#endif
   }
 
   let hHook: HHOOK? =
       SetWindowsHookExW(WH_CALLWNDPROC, pApplicationWindowProc, hSwiftWin32, 0)
   if hHook == nil {
-#if ENABLE_LOGGING
     log.error("SetWindowsHookExW: \(GetLastError())")
-#endif
   }
 
   if Application.shared.delegate?
@@ -118,9 +112,7 @@ public func ApplicationMain(_ argc: Int32,
 
   if let hHook = hHook {
     if !UnhookWindowsHookEx(hHook) {
-#if ENABLE_LOGGING
       log.error("UnhookWindowsHookEx: \(GetLastError())")
-#endif
     }
   }
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -39,9 +39,9 @@ target_link_libraries(SwiftWin32 PUBLIC
   $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   ComCtl32
   User32)
-if(ENABLE_LOGGING)
+if(WITH_SWIFT_LOG)
   target_compile_definitions(SwiftWin32 PRIVATE
-    ENABLE_LOGGING)
+    WITH_SWIFT_LOG)
   if(TARGET SwiftLog::Logging)
     target_link_libraries(SwiftWin32 PUBLIC
       SwiftLog::Logging)

--- a/Sources/Support/Logging.swift
+++ b/Sources/Support/Logging.swift
@@ -27,8 +27,20 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#if ENABLE_LOGGING
+#if WITH_SWIFT_LOG
 import Logging
 
 internal let log: Logger = Logger(label: "org.compnerd.swift-win32")
+#else
+import WinSDK
+
+internal struct log {
+  static func error(_ message: String) {
+    OutputDebugStringW("ERROR: \(message)".LPCWSTR)
+  }
+
+  static func warning(_ message: String) {
+    OutputDebugStringW("WARNING: \(message)".LPCWSTR)
+  }
+}
 #endif

--- a/Sources/UI/Device.swift
+++ b/Sources/UI/Device.swift
@@ -41,9 +41,7 @@ public struct Device {
         Array<WCHAR>(repeating: 0, count: Int(MAX_COMPUTERNAME_LENGTH) + 1)
     var nSize: DWORD = DWORD(szBuffer.count)
     guard GetComputerNameW(&szBuffer, &nSize) else {
-#if ENABLE_LOGGING
       log.warning("GetComputerNameW: \(GetLastError())")
-#endif
       return ""
     }
     return String(decodingCString: szBuffer, as: UTF16.self)
@@ -66,9 +64,7 @@ public struct Device {
         continue
       }
       guard lStatus == 0 else {
-#if ENABLE_LOGGING
         log.warning("RegGetValueW: \(lStatus)")
-#endif
         return ""
       }
       return String(decodingCString: szBuffer, as: UTF16.self)
@@ -91,9 +87,7 @@ public struct Device {
         continue
       }
       guard lStatus == 0 else {
-#if ENABLE_LOGGING
         log.warning("RegGetValueW: \(lStatus)")
-#endif
         return ""
       }
       return String(decodingCString: szBuffer, as: UTF16.self)

--- a/Sources/UI/Font.swift
+++ b/Sources/UI/Font.swift
@@ -52,9 +52,7 @@ public class Font {
 
     if GetObjectW(self.hFont.value, Int32(MemoryLayout<LOGFONTW>.size),
                   &lfFont) == 0 {
-#if ENABLE_LOGGING
       log.error("GetObjectW: \(GetLastError())")
-#endif
       return ""
     }
 

--- a/Sources/UI/TraitCollection.swift
+++ b/Sources/UI/TraitCollection.swift
@@ -139,9 +139,7 @@ private func GetCurrentColorScheme() -> UserInterfaceStyle {
                    DWORD(RRF_RT_REG_DWORD), nil,
                    &dwAppsUseLightTheme, &cbAppsUseLightTheme)
   guard lStatus == S_OK else {
-#if ENABLE_LOGGING
     log.error("RegGetValueW: \(lStatus)")
-#endif
     return .unspecified
   }
   return dwAppsUseLightTheme == 0 ? .dark : .light
@@ -171,9 +169,7 @@ private func GetCurrentAccessibilityContrast() -> AccessibilityContrast {
   var hcContrast: HIGHCONTRASTW = HIGHCONTRASTW()
   hcContrast.cbSize = UINT(MemoryLayout<HIGHCONTRASTW>.size)
   if !SystemParametersInfoW(UINT(SPI_GETHIGHCONTRAST), 0, &hcContrast, 0) {
-#if ENABLE_LOGGING
     log.error("SystemParametersInfoW: \(GetLastError())")
-#endif
     return .unspecified
   }
   return Int32(hcContrast.dwFlags) & HCF_HIGHCONTRASTON == HCF_HIGHCONTRASTON
@@ -183,9 +179,7 @@ private func GetCurrentAccessibilityContrast() -> AccessibilityContrast {
 private func GetCurrentLayoutDirection() -> TraitEnvironmentLayoutDirection {
   var dwDefaultLayout: DWORD = 0
   if !GetProcessDefaultLayout(&dwDefaultLayout) {
-#if ENABLE_LOGGING
     log.error("GetProcessDefaultLayout: \(GetLastError())")
-#endif
     return .unspecified
   }
   return dwDefaultLayout == LAYOUT_RTL ? .rightToLeft : .leftToRight

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -54,9 +54,7 @@ public class View {
     // `CW_USEDEFAULT`, `ShowWindow` will be invoked with `SW_SHOW`.
     if self.frame.origin.x == Double(CW_USEDEFAULT) &&
        style.base & DWORD(WS_OVERLAPPEDWINDOW) == 0 {
-#if ENABLE_LOGGING
       log.warning("CW_USEDEFAULT is only valid on WS_OVERLAPPEDWINDOW windows")
-#endif
       self.frame.origin = Point(x: 0, y: 0)
     }
 
@@ -64,9 +62,7 @@ public class View {
     // `WS_OVERLAPPEDWINDOW` window, `height` is ignored.
     if self.frame.size.width == Double(CW_USEDEFAULT) &&
        style.base & DWORD(WS_OVERLAPPEDWINDOW) == 0 {
-#if ENABLE_LOGGING
       log.warning("CW_USEDEFAULT is only valid on WS_OVERLAPPEDWINDOW windows")
-#endif
       self.frame.size = Size(width: 0, height: 0)
     }
 
@@ -84,9 +80,7 @@ public class View {
        frame.size.height == Double(CW_USEDEFAULT) {
       var r: RECT = RECT()
       if !GetWindowRect(self.hWnd, &r) {
-#if ENABLE_LOGGING
         log.warning("GetWindowRect: \(GetLastError())")
-#endif
         return
       }
       self.frame = Rect(from: r)
@@ -109,11 +103,9 @@ public class View {
       return
     }
     view.style.base |= DWORD(WS_CHILD)
-#if ENABLE_LOGGING
     if view.style.base & ~DWORD(WS_OVERLAPPEDWINDOW) == DWORD(WS_OVERLAPPEDWINDOW) {
       log.warning("child windows may not set WS_OVERLAPPEDWINDOW")
     }
-#endif
 
     SetParent(view.hWnd, self.hWnd)
 
@@ -122,9 +114,7 @@ public class View {
     var r = RECT(from: view.frame)
     if !AdjustWindowRectExForDpi(&r, view.style.base, false,
                                  view.style.extended, dpi) {
-#if ENABLE_LOGGING
       log.warning("AdjustWindowRectExForDpi: \(GetLastError())")
-#endif
     }
     view.frame = Rect(from: r)
 


### PR DESCRIPTION
Fallback to `OutputDebugStringW` when swift-log is unavailable.  Rename
the `ENABLE_LOGGING` option to `WITH_SWIFT_LOG` as it is intended now to
build with support for swift-log.  This allows us to provide logging
even if `swift-log` is unavailable.