### PR TITLE
UI: add a font backing store for TextField

### DIFF
--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -43,12 +43,15 @@ public class TextField: Control {
 
   public weak var delegate: TextFieldDelegate?
 
+  private var _font: Font?
   public var font: Font? {
     get {
+      guard _font == nil else { return _font }
       let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
       return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
     }
     set(font) {
+      self._font = font
       SendMessageW(hWnd, UINT(WM_SETFONT),
                    unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
     }


### PR DESCRIPTION
The font was not being stored as the property was a computed property.
Add an explicit backing store to ensure that we do not loose the font.