### PR TITLE
UI: add `TextAlignment` enumeration for `TextField`

### DIFF
--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -38,6 +38,14 @@ internal let SwiftTextFieldProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, u
   return DefSubclassProc(hWnd, uMsg, wParam, lParam)
 }
 
+public enum TextAlignment: Int {
+case natural
+case left
+case right
+case center
+case justified
+}
+
 public class TextField: Control {
   public static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
 
@@ -70,6 +78,53 @@ public class TextField: Control {
     }
     set(value) {
       SetWindowTextW(hWnd, value?.LPCWSTR)
+    }
+  }
+
+  public var textAlignment: TextAlignment {
+    get {
+      var pfFormat: PARAFORMAT = PARAFORMAT()
+      pfFormat.cbSize = UINT(MemoryLayout<PARAFORMAT>.size)
+      pfFormat.dwMask = DWORD(PFM_ALIGNMENT)
+
+      _ = withUnsafePointer(to: &pfFormat) {
+        SendMessageW(hWnd, UINT(EM_GETPARAFORMAT), 0, LPARAM(Int(bitPattern: $0)))
+      }
+
+      switch pfFormat.wAlignment {
+      case WORD(PFA_LEFT):
+        return .left
+      case WORD(PFA_RIGHT):
+        return .right
+      case WORD(PFA_CENTER):
+        return .center
+      case WORD(PFA_JUSTIFY):
+        return .justified
+      default:
+        fatalError("unknown alignment `\(pfFormat.wAlignment)`")
+      }
+    }
+    set(value) {
+      var pfFormat: PARAFORMAT = PARAFORMAT()
+      pfFormat.cbSize = UINT(MemoryLayout<PARAFORMAT>.size)
+      pfFormat.dwMask = DWORD(PFM_ALIGNMENT)
+
+      switch value {
+      case .natural:
+        fatalError("do not know how to render `\(value)` text")
+      case .left:
+        pfFormat.wAlignment = WORD(PFA_LEFT)
+      case .right:
+        pfFormat.wAlignment = WORD(PFA_RIGHT)
+      case .center:
+        pfFormat.wAlignment = WORD(PFA_CENTER)
+      case .justified:
+        pfFormat.wAlignment = WORD(PFA_JUSTIFY)
+      }
+
+      _ = withUnsafePointer(to: &pfFormat) {
+        SendMessageW(hWnd, UINT(EM_SETPARAFORMAT), 0, LPARAM(Int(bitPattern: $0)))
+      }
     }
   }
 


### PR DESCRIPTION
`TextField` should allow setting the text alignment.  However, `EDIT`
controls cannot dynamically change the text alignment.  Now that
`TextField` is backed by a Rich Edit control, we can switch the
alignment freely.