### PR TITLE
UI: remove `class:style:` from `init`

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -64,28 +64,27 @@ internal let SwiftButtonProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 }
 
 public class Button: Control {
-  public static let `class`: WindowClass = WindowClass(named: "BUTTON")
+  internal static let `class`: WindowClass = WindowClass(named: "BUTTON")
+  internal static let style: WindowStyle =
+      (base: DWORD(WS_TABSTOP | WS_VISIBLE | BS_PUSHBUTTON), extended: 0)
 
   public weak var delegate: ButtonDelegate?
 
-  public override init(frame: Rect = .default, `class`: WindowClass = Button.class,
-                       style: WindowStyle = (base: DWORD(WS_TABSTOP | WS_VISIBLE | BS_PUSHBUTTON),
-                                             extended: 0)) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect = .default) {
+    super.init(frame: frame, class: Button.class, style: Button.style)
     SetWindowSubclass(hWnd, SwiftButtonProc, UINT_PTR(1),
                       unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
-  }
-
-  public convenience init(frame: Rect = .zero, `class`: WindowClass = Button.class,
-                          style: WindowStyle = (base: DWORD(WS_TABSTOP | WS_VISIBLE | BS_PUSHBUTTON),
-                                                extended: 0),
-                          title: String) {
-    self.init(frame: frame, class: `class`, style: style)
-    setTitle(title, forState: .normal)
   }
 
   // FIXME(compnerd) handle title setting for different states
   public func setTitle(_ title: String?, forState _: Control.State) {
     SetWindowTextW(hWnd, title?.LPCWSTR)
+  }
+}
+
+extension Button {
+  public convenience init(frame: Rect = .zero, title: String) {
+    self.init(frame: frame)
+    setTitle(title, forState: .normal)
   }
 }

--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -30,9 +30,9 @@
 import WinSDK
 
 public class Label: Control {
-  public static let `class`: WindowClass = WindowClass(named: "STATIC")
-  public static let style: WindowStyle =
-      WindowStyle(base: DWORD(WS_TABSTOP | WS_VISIBLE), extended: 0)
+  internal static let `class`: WindowClass = WindowClass(named: "STATIC")
+  internal static let style: WindowStyle =
+      (base: DWORD(WS_TABSTOP | WS_VISIBLE), extended: 0)
 
   public var font: Font! {
     get {
@@ -61,14 +61,14 @@ public class Label: Control {
     }
   }
 
-  public override init(frame: Rect, `class`: WindowClass = Label.class,
-                       style: WindowStyle = Label.style) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect) {
+    super.init(frame: frame, class: Label.class, style: Label.style)
   }
+}
 
-  public convenience init(frame: Rect = .zero, `class`: WindowClass = Label.class,
-                          style: WindowStyle = Label.style, title: String) {
-    self.init(frame: frame, class: `class`, style: style)
+extension Label {
+  public convenience init(frame: Rect = .zero, title: String) {
+    self.init(frame: frame)
     SetWindowTextW(hWnd, title.LPCWSTR)
   }
 }

--- a/Sources/UI/ProgressView.swift
+++ b/Sources/UI/ProgressView.swift
@@ -30,12 +30,11 @@
 import WinSDK
 
 public class ProgressView: Control {
-  public static let `class`: WindowClass = WindowClass(named: PROGRESS_CLASS)
+  internal static let `class`: WindowClass = WindowClass(named: PROGRESS_CLASS)
+  internal static let style: WindowStyle = (base: DWORD(WS_VISIBLE), extended: 0)
 
-  public override init(frame: Rect, `class`: WindowClass = ProgressView.class,
-                       style: WindowStyle = (base: DWORD(WS_VISIBLE),
-                                             extended: 0)) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect) {
+    super.init(frame: frame, class: ProgressView.class, style: ProgressView.style)
     SendMessageW(hWnd, UINT(PBM_SETRANGE32), 0, 100)
     SendMessageW(hWnd, UINT(PBM_SETPOS), 0, 0)
   }

--- a/Sources/UI/Slider.swift
+++ b/Sources/UI/Slider.swift
@@ -30,10 +30,9 @@
 import WinSDK
 
 public class Slider: Control {
-  public static let `class`: WindowClass = WindowClass(named: TRACKBAR_CLASS)
-  public static let style: WindowStyle =
-      WindowStyle(base: DWORD(WS_VISIBLE | TBS_TRANSPARENTBKGND),
-                  extended: 0)
+  internal static let `class`: WindowClass = WindowClass(named: TRACKBAR_CLASS)
+  internal static let style: WindowStyle =
+      (base: DWORD(WS_VISIBLE | TBS_TRANSPARENTBKGND), extended: 0)
 
   public var value: Float {
     get { Float(SendMessageW(hWnd, UINT(TBM_GETPOS), 0, 0)) / 100.0 }
@@ -56,9 +55,8 @@ public class Slider: Control {
     }
   }
 
-  public override init(frame: Rect, `class`: WindowClass = Slider.class,
-                       style: WindowStyle = Slider.style) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect) {
+    super.init(frame: frame, class: Slider.class, style: Slider.style)
     SendMessageW(hWnd, UINT(TBM_SETLINESIZE), WPARAM(1), LPARAM(100))
   }
 }

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -47,7 +47,9 @@ case justified
 }
 
 public class TextField: Control {
-  public static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
+  internal static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
+  internal static let style: WindowStyle =
+      (base: DWORD(WS_BORDER | WS_TABSTOP | WS_VISIBLE | ES_AUTOHSCROLL), extended: 0)
 
   public weak var delegate: TextFieldDelegate?
 
@@ -128,10 +130,8 @@ public class TextField: Control {
     }
   }
 
-  public override init(frame: Rect = .default, `class`: WindowClass = TextField.class,
-                       style: WindowStyle = (base: DWORD(WS_BORDER | WS_TABSTOP | WS_VISIBLE | ES_AUTOHSCROLL),
-                                             extended: 0)) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect = .default) {
+    super.init(frame: frame, class: TextField.class, style: TextField.style)
 
     // Remove the `WS_EX_CLIENTEDGE` which gives it a flat appearance
     let lExtendedStyle: LONG = GetWindowLongW(hWnd, GWL_EXSTYLE);

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -37,10 +37,9 @@ internal let SwiftTextViewProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uI
 
 // FIXME(compnerd) we would like this to derive from ScrollView
 public class TextView: View {
-  public static let `class`: WindowClass = WindowClass(named: "EDIT")
-  public static let style: WindowStyle =
-      WindowStyle(base: DWORD(WS_BORDER | WS_HSCROLL | WS_TABSTOP | WS_VISIBLE | WS_VSCROLL | ES_MULTILINE),
-                  extended: 0)
+  internal static let `class`: WindowClass = WindowClass(named: "EDIT")
+  internal static let style: WindowStyle =
+      (base: DWORD(WS_BORDER | WS_HSCROLL | WS_TABSTOP | WS_VISIBLE | WS_VSCROLL | ES_MULTILINE), extended: 0)
 
   public var editable: Bool {
     get {
@@ -78,9 +77,8 @@ public class TextView: View {
     }
   }
 
-  public override init(frame: Rect = .default, `class`: WindowClass = TextView.class,
-                       style: WindowStyle = TextView.style) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect = .default) {
+    super.init(frame: frame, class: TextView.class, style: TextView.style)
     SetWindowSubclass(hWnd, SwiftTextViewProc, UINT_PTR(1),
                       unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
   }

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -29,7 +29,7 @@
 
 import WinSDK
 
-public typealias WindowStyle = (base: DWORD, extended: DWORD)
+internal typealias WindowStyle = (base: DWORD, extended: DWORD)
 
 public class View {
   internal var hWnd: HWND
@@ -57,7 +57,7 @@ public class View {
     }
   }
 
-  public init(frame: Rect, `class`: WindowClass, style: WindowStyle) {
+  internal init(frame: Rect, `class`: WindowClass, style: WindowStyle) {
     self.class = `class`
     _ = self.class.register()
     self.style = style

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -94,26 +94,25 @@ internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 }
 
 public class Window: View {
-  public static let `class`: WindowClass =
+  internal static let `class`: WindowClass =
       WindowClass(hInst: GetModuleHandleW(nil), name: "Swift.Window",
                   hbrBackground: GetSysColorBrush(COLOR_3DFACE),
                   hCursor: LoadCursorW(nil, IDC_ARROW))
-  public static let style: WindowStyle =
-      WindowStyle(base: DWORD(CS_HREDRAW | CS_VREDRAW | Int32(WS_OVERLAPPEDWINDOW) | WS_VISIBLE),
-                  extended: 0)
+  internal static let style: WindowStyle =
+      (base: DWORD(CS_HREDRAW | CS_VREDRAW | Int32(WS_OVERLAPPEDWINDOW) | WS_VISIBLE), extended: 0)
 
   public weak var delegate: WindowDelegate?
 
-  public override init(frame: Rect, `class`: WindowClass = Window.class,
-                       style: WindowStyle = Window.style) {
-    super.init(frame: frame, class: `class`, style: style)
+  public init(frame: Rect) {
+    super.init(frame: frame, class: Window.class, style: Window.style)
     SetWindowSubclass(hWnd, SwiftWindowProc, UINT_PTR(0),
                       unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
   }
+}
 
-  public convenience init(frame: Rect = .zero, `class`: WindowClass = Window.class,
-                          style: WindowStyle = Window.style, title: String) {
-    self.init(frame: frame, class: `class`, style: style)
+extension Window {
+  public convenience init(frame: Rect = .zero, title: String) {
+    self.init(frame: frame)
     SetWindowTextW(hWnd, title.LPCWSTR)
   }
 }

--- a/Sources/UI/WindowClass.swift
+++ b/Sources/UI/WindowClass.swift
@@ -29,10 +29,10 @@
 
 import WinSDK
 
-public typealias WindowProc =
+internal typealias WindowProc =
     @convention(c) (HWND?, UINT, WPARAM, LPARAM) -> LRESULT
 
-public class WindowClass {
+internal class WindowClass {
   internal var name: [WCHAR]
 
   internal var hInstance: HINSTANCE?


### PR DESCRIPTION
Remove the `class` and `style parameters to present a more complete
veneer over the Win32/GDI interfaces.  This moves us closer towards
removing the exposure to Win32 from the user's perspective.