### PR TITLE
UI: handle class styles properly

### DIFF
--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -96,10 +96,11 @@ internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 public class Window: View {
   internal static let `class`: WindowClass =
       WindowClass(hInst: GetModuleHandleW(nil), name: "Swift.Window",
+                  style: UInt32(CS_HREDRAW | CS_VREDRAW),
                   hbrBackground: GetSysColorBrush(COLOR_3DFACE),
                   hCursor: LoadCursorW(nil, IDC_ARROW))
   internal static let style: WindowStyle =
-      (base: DWORD(CS_HREDRAW | CS_VREDRAW | Int32(WS_OVERLAPPEDWINDOW) | WS_VISIBLE), extended: 0)
+      (base: DWORD(WS_OVERLAPPEDWINDOW | UInt32(WS_VISIBLE)), extended: 0)
 
   public weak var delegate: WindowDelegate?
 


### PR DESCRIPTION
Thanks to @farzonl for pointing out that the class styles were not being
applied to the Window class.  They were incorrectly being applied as
Window styles rather than class styles.