### PR TITLE
UI: redo class definition for rich edit

### DIFF
--- a/Sources/Support/WinSDK+Extensions.swift
+++ b/Sources/Support/WinSDK+Extensions.swift
@@ -62,5 +62,5 @@ public let HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY = HKEY(bitPattern: 0x80000007)
 
 #if swift(<6.0)
 // Richedit.h
-public let MSFTEDIT_CLASS: [WCHAR] = Array<WCHAR>("RICHEDIT50W".utf16)
+public let MSFTEDIT_CLASS: String = "RICHEDIT50W"
 #endif

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -70,14 +70,14 @@ public class View {
     // We only check `x` because if `x` is `CW_USEDEFAULT` for a
     // `WS_OVERLAPPEDWINDOW` window, then `y` is ignored; if `y` is
     // `CW_USEDEFAULT`, `ShowWindow` will be invoked with `SW_SHOW`.
-    if self.frame.origin.x == Double(CW_USEDEFAULT) && !bOverlappedWindow {
+    if !bOverlappedWindow && frame.origin.x == Double(CW_USEDEFAULT) {
       log.warning("CW_USEDEFAULT is only valid on WS_OVERLAPPEDWINDOW windows")
       self.frame.origin = Point(x: 0, y: 0)
     }
 
     // We only check `width` because if `width` is CW_USEDEFAULT` for a
     // `WS_OVERLAPPEDWINDOW` window, `height` is ignored.
-    if self.frame.size.width == Double(CW_USEDEFAULT) && !bOverlappedWindow {
+    if !bOverlappedWindow && frame.size.width == Double(CW_USEDEFAULT) {
       log.warning("CW_USEDEFAULT is only valid on WS_OVERLAPPEDWINDOW windows")
       self.frame.size = Size(width: 0, height: 0)
     }
@@ -91,7 +91,7 @@ public class View {
                         Int32(bOverlappedWindow ? self.frame.origin.y : 0),
                         Int32(self.frame.size.width),
                         Int32(self.frame.size.height),
-                        nil, nil, GetModuleHandleW(nil), nil)
+                        nil, nil, GetModuleHandleW(nil), nil)!
 
     // If `CW_USEDEFAULT` was used, query the actual allocated rect
     if frame.origin.x == Double(CW_USEDEFAULT) ||

--- a/Sources/UI/WindowClass.swift
+++ b/Sources/UI/WindowClass.swift
@@ -62,10 +62,6 @@ internal class WindowClass {
     }
   }
 
-  internal init(named: Array<WCHAR>) {
-    self.name = named
-  }
-
   public init(named: String) {
     self.name = named.LPCWSTR
   }


### PR DESCRIPTION
Use a String for the class name rather than an array.  Swap the
condition for the overlapped window frame check as overlapped is
comparatively less likely.  Force unwrap the pointer from
`CreateWindowExW` which returns a nullable pointer.