### PR TITLE
UI: enable mapping the window to the screen

### DIFF
--- a/Sources/UI/Screen.swift
+++ b/Sources/UI/Screen.swift
@@ -93,7 +93,8 @@ public final class Screen {
       _ = GetScaleFactorForMonitor(hMonitor, &dsfDevceScaleFactor)
 
       let screen: Screen =
-          Screen(height: info.s.rcMonitor.bottom, width: info.s.rcMonitor.right,
+          Screen(handle: hMonitor!,
+                 height: info.s.rcMonitor.bottom, width: info.s.rcMonitor.right,
                  scale: dsfDevceScaleFactor.factor)
 
       // The main screen is always at index 0
@@ -125,7 +126,13 @@ public final class Screen {
   /// The native scale factor for the physical screen.
   public let nativeScale: Double
 
-  private init(height: LONG, width: LONG, scale: Double) {
+  /// The handle to the monitor that the screen represents.
+  private let hMonitor: HMONITOR!
+
+  private init(handle hMonitor: HMONITOR!, height: LONG, width: LONG,
+               scale: Double) {
+    self.hMonitor = hMonitor
+
     self.bounds = Rect(origin: Point(x: 0, y: 0),
                        size: Size(width: Double(width) / scale,
                                   height: Double(height) / scale))
@@ -133,6 +140,16 @@ public final class Screen {
         Rect(origin: Point(x: 0, y: 0),
              size: Size(width: Double(width), height: Double(height)))
     self.nativeScale = scale
+  }
+}
+
+extension Screen {
+  internal static func == (_ lhs: Screen, _ rhs: HMONITOR) -> Bool {
+    return lhs.hMonitor == rhs
+  }
+
+  internal static func == (_ lhs: HMONITOR, _ rhs: Screen) -> Bool {
+    return rhs.hMonitor == lhs
   }
 }
 

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -94,6 +94,15 @@ public class Window: View {
 
   public weak var delegate: WindowDelegate?
 
+  // TODO(compnerd) remove this in favour of scene management interface;
+  // windowScene provides the scene associated with the window, and the scene is
+  // attached to a window.
+  public var screen: Screen {
+    let hMonitor: HMONITOR =
+        MonitorFromWindow(hWnd, DWORD(MONITOR_DEFAULTTOPRIMARY))
+    return Screen.screens.filter { $0 == hMonitor }.first!
+  }
+
   public init(frame: Rect) {
     super.init(frame: frame, class: Window.class, style: Window.style)
     SetWindowSubclass(hWnd, SwiftWindowProc, UINT_PTR(0),


### PR DESCRIPTION
This adds the monitor handle to the screen to allow mapping the screen
to the monitor.

Add the helper `==` operators for comparing a screen to a `HMONITOR`.
These are internal as the user should not need to be aware of the
Windows types.

Add the screen property to the Window type.  This allows querying the
screen from the Window.