### PR TITLE
Application: extract `GetMessageW` overloads

### DIFF
--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -129,12 +129,6 @@ public func ApplicationMain(_ argc: Int32,
     return EXIT_FAILURE
   }
 
-  // `GetMessageW` returns `BOOL` but can return `-1` in the case of an error.
-  // Explicitly convert the signature to unwrap the `BOOL` to `CInt`.
-  let GetMessageW: (LPMSG?, HWND?, UINT, UINT) -> CInt =
-        unsafeBitCast(WinSDK.GetMessageW,
-                      to: ((LPMSG?, HWND?, UINT, UINT) -> CInt).self)
-
   var msg: MSG = MSG()
   while GetMessageW(&msg, nil, 0, 0) > 0 {
     TranslateMessage(&msg)

--- a/Sources/Support/WinSDK+Extensions.swift
+++ b/Sources/Support/WinSDK+Extensions.swift
@@ -64,3 +64,18 @@ public let HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY = HKEY(bitPattern: 0x80000007)
 // Richedit.h
 public let MSFTEDIT_CLASS: String = "RICHEDIT50W"
 #endif
+
+// `GetMessageW` returns `BOOL` but can return `-1` in the case of an error.
+// Explicitly convert the signature to unwrap the `BOOL` to `CInt`.
+func GetMessageW(_ lpMsg: LPMSG?, _ hWnd: HWND?, _ wMsgFilterMin: UINT,
+                 _ wMsgFilterMax: UINT) -> Bool {
+  return WinSDK.GetMessageW(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax)
+}
+
+func GetMessageW(_ lpMsg: LPMSG?, _ hWnd: HWND?, _ wMsgFilterMin: UINT,
+                 _ wMsgFilterMax: UINT) -> CInt {
+  let pfnGetMessageW: (LPMSG?, HWND?, UINT, UINT) -> CInt =
+      unsafeBitCast(WinSDK.GetMessageW,
+                    to: ((LPMSG?, HWND?, UINT, UINT) -> CInt).self)
+  return pfnGetMessageW(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax)
+}


### PR DESCRIPTION
Provide overloads to allow the extraction of the integral value from the
`BOOL` return type.