### PR TITLE
UI: remove `OnDestroy` from `WindowDelegate`

### DIFF
--- a/Examples/Calculator.swift
+++ b/Examples/Calculator.swift
@@ -28,7 +28,6 @@
  **/
 
 import func WinSDK.GetWindowTextW
-import func WinSDK.PostQuitMessage
 import let WinSDK.CW_USEDEFAULT
 import struct WinSDK.DWORD
 import struct WinSDK.HWND
@@ -85,12 +84,6 @@ private struct CalculatorState {
 
 private class CalculatorWindowDelegate: WindowDelegate {
   weak var calculator: Calculator?
-
-  func OnDestroy(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM)
-      -> LRESULT {
-    PostQuitMessage(0)
-    return 0
-  }
 
   func OnCommand(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM)
       -> LRESULT {

--- a/Examples/HelloSwift.swift
+++ b/Examples/HelloSwift.swift
@@ -31,12 +31,6 @@ import WinSDK
 import SwiftWin32
 
 class EventHandler: WindowDelegate {
-  func OnDestroy(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM)
-      -> LRESULT {
-    PostQuitMessage(0)
-    return 0
-  }
-
   func OnCommand(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM)
       -> LRESULT {
     MessageBoxW(nil, "Swift/Win32 Demo!".LPCWSTR,

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -33,7 +33,6 @@ public protocol WindowDelegate: class {
   func OnCreate(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT
   func OnPaint(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT
   func OnCommand(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT
-  func OnDestroy(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT
 }
 
 public extension WindowDelegate {
@@ -42,10 +41,6 @@ public extension WindowDelegate {
   }
 
   func OnPaint(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT {
-    return 1
-  }
-
-  func OnDestroy(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT {
     return 1
   }
 
@@ -66,9 +61,10 @@ internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
       return 0
     }
   case UINT(WM_DESTROY):
-    if window?.delegate?.OnDestroy(hWnd, wParam, lParam) == 0 {
-      return 0
-    }
+    // TODO(compnerd) we should handle multiple scenes, which can have multiple
+    // Windows, so the destruction of a window should not post the quit message
+    // to the message loop.
+    PostQuitMessage(0)
   case UINT(WM_COMMAND):
     if window?.delegate?.OnCommand(hWnd, wParam, lParam) == 0 {
       return 0


### PR DESCRIPTION
There is no need to expose the `OnDestroy` event to the user.  This is
handled properly by default.  The only need is to post the quit message
(`WM_QUIT`) when the window is destroyed to terminate the app.