### PR TITLE
UI: start wiring up `WM_DPICHANGED` notifications

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(SwiftWin32 SHARED
   UI/TextField.swift
   UI/TextView.swift
   UI/TraitCollection.swift
+  UI/TraitEnvironment.swift
   UI/View.swift
   UI/Window.swift
   UI/WindowClass.swift)

--- a/Sources/UI/TraitEnvironment.swift
+++ b/Sources/UI/TraitEnvironment.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+public protocol TraitEnvironment {
+  var traitCollection: TraitCollection { get }
+  func traitCollectionDidChange(_ previousTraitCollection: TraitCollection?)
+}

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -60,6 +60,11 @@ internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
     if window?.delegate?.OnCommand(hWnd, wParam, lParam) == 0 {
       return 0
     }
+  case UINT(WM_DPICHANGED):
+    if let hMonitor = MonitorFromWindow(hWnd, DWORD(MONITOR_DEFAULTTONULL)) {
+      let screen = Screen.screens.filter { $0 == hMonitor }.first
+      screen?.traitCollectionDidChange(screen?.traitCollection)
+    }
   default:
     break
   }


### PR DESCRIPTION
Intercept the `WM_DPICHANGED` message in the window hook procedure.
That notification is then broadcasted to the Screen enumeration which
represents the display (i.e. trigger a refresh on all monitors).

In theory, we should be able to identify the intended recipient, and use
the HWND to map the monitor, refreshing just that monitor.  This would
make the processing significantly cheaper.

The intent here is to identify the screen, then broadcast the DPI change
notification to all the windows on that screen to trigger a re-layout of
the window, properly handling the scaling change.