### PR TITLE
Application: track application Windows

### DIFF
--- a/Examples/Calculator.swift
+++ b/Examples/Calculator.swift
@@ -202,6 +202,8 @@ private class Calculator {
     self.window.addSubviews(self.btnOperations)
 
     self.window.addSubview(self.btnDecimal)
+
+    self.window.makeKeyAndVisible()
   }
 }
 

--- a/Examples/HelloSwift.swift
+++ b/Examples/HelloSwift.swift
@@ -102,6 +102,8 @@ deserunt mollit anim id est laborum.\r\n
     self.slider.maximumValue = 100.0
     self.slider.value = 48.0
 
+    window.makeKeyAndVisible()
+
     return true
   }
 

--- a/Sources/Application/Application.swift
+++ b/Sources/Application/Application.swift
@@ -28,13 +28,22 @@
  **/
 
 public class Application: _TriviallyConstructible {
+  /// Getting the App Instance
   public static var shared: Application = Application()
 
+  /// Managing the App's Behaviour
   public var delegate: ApplicationDelegate?
+
+  /// Getting the Application State
   public internal(set) var state: Application.State
+
+  /// Getting App Windows
+  public internal(set) var keyWindow: Window?
+  public internal(set) var windows: [Window]
 
   public required init() {
     self.state = .active
+    self.windows = []
   }
 }
 


### PR DESCRIPTION
Add new `Window` APIs to enable tracking of Window instances in the
application.  This starts laying the framework to support modelling
applications with multiple scenes.