### PR TITLE
UI: add backing store for Font

### DIFF
--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -34,14 +34,17 @@ public class Label: Control {
   internal static let style: WindowStyle =
       (base: DWORD(WS_TABSTOP | WS_VISIBLE), extended: 0)
 
+  private var _font: Font?
   public var font: Font! {
     get {
+      guard _font == nil else { return _font }
       let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
       return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
     }
     set(font) {
+      self._font = font
       SendMessageW(hWnd, UINT(WM_SETFONT),
-                   unsafeBitCast(font.hFont.value, to: WPARAM.self), LPARAM(1))
+                   unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
     }
   }
 

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -51,12 +51,15 @@ public class TextView: View {
     }
   }
 
+  private var _font: Font?
   public var font: Font? {
     get {
+      guard _font == nil else { return _font }
       let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
       return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
     }
     set(font) {
+      self._font = font
       SendMessageW(hWnd, UINT(WM_SETFONT),
                    unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
     }


### PR DESCRIPTION
We would immediately drop the Font which would free the font.  This
resulted in the font setting never taking effect.  This is the same
issue as the `TextField`.  Replicate the fix to `Label` and `TextView`.