### PR TITLE
Support: introduce WindowText property wrapper

### DIFF
--- a/Examples/HelloSwift.swift
+++ b/Examples/HelloSwift.swift
@@ -30,6 +30,13 @@
 import WinSDK
 import SwiftWin32
 
+internal extension Label {
+  convenience init(frame: Rect, title: String) {
+    self.init(frame: frame)
+    self.text = title
+  }
+}
+
 class EventHandler: WindowDelegate {
   func OnCommand(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM)
       -> LRESULT {

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(SwiftWin32 PRIVATE
 target_sources(SwiftWin32 PRIVATE
   Support/Logging.swift
   Support/Rect+UIExtensions.swift
+  Support/PropertyWrappers.swift
   Support/String.swift
   Support/WindowsHandle.swift
   Support/WinSDK+Extensions.swift)

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -67,21 +67,8 @@ public class TextField: Control {
     }
   }
 
-  public var text: String? {
-    get {
-      let szLength: Int32 = GetWindowTextLengthW(hWnd)
-
-      let buffer: UnsafeMutablePointer<WCHAR> =
-        UnsafeMutablePointer<WCHAR>.allocate(capacity: Int(szLength) + 1)
-      defer { buffer.deallocate() }
-
-      GetWindowTextW(hWnd, buffer, szLength + 1)
-      return String(decodingCString: buffer, as: UTF16.self)
-    }
-    set(value) {
-      SetWindowTextW(hWnd, value?.LPCWSTR)
-    }
-  }
+  @_Win32WindowText
+  public var text: String?
 
   public var textAlignment: TextAlignment {
     get {

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -65,21 +65,8 @@ public class TextView: View {
     }
   }
 
-  public var text: String? {
-    get {
-      let szLength: Int32 = GetWindowTextLengthW(hWnd)
-
-      let buffer: UnsafeMutablePointer<WCHAR> =
-        UnsafeMutablePointer<WCHAR>.allocate(capacity: Int(szLength) + 1)
-      defer { buffer.deallocate() }
-
-      GetWindowTextW(hWnd, buffer, szLength + 1)
-      return String(decodingCString: buffer, as: UTF16.self)
-    }
-    set(value) {
-      SetWindowTextW(hWnd, value?.LPCWSTR)
-    }
-  }
+  @_Win32WindowText
+  public var text: String?
 
   public init(frame: Rect = .default) {
     super.init(frame: frame, class: TextView.class, style: TextView.style)


### PR DESCRIPTION
The window text property is very useful as it is used in a number of
places.  It is backed by an opaque storage that is handled by the
implementation.  Querying requires determining the size and then
allocating a buffer and retrieving a copy.

The `_Win32WindowText` property wrapper allows exposing the window
property itself through an alternate name.  This requires some extra
setup to pass along the view that the property wrapper is associated
with to allow setting up the `HWND`.  However, this allows for a single
implementation to be shared across all the various sites.