### PR TITLE
UI: make `class` and `style` private

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -64,8 +64,8 @@ internal let SwiftButtonProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 }
 
 public class Button: Control {
-  internal static let `class`: WindowClass = WindowClass(named: "BUTTON")
-  internal static let style: WindowStyle =
+  private static let `class`: WindowClass = WindowClass(named: "BUTTON")
+  private static let style: WindowStyle =
       (base: DWORD(WS_TABSTOP | WS_VISIBLE | BS_PUSHBUTTON), extended: 0)
 
   public weak var delegate: ButtonDelegate?

--- a/Sources/UI/DatePicker.swift
+++ b/Sources/UI/DatePicker.swift
@@ -43,9 +43,9 @@ case inline
 }
 
 public class DatePicker: Control {
-  internal static let `class`: WindowClass =
+  private static let `class`: WindowClass =
       WindowClass(named: DATETIMEPICK_CLASS)
-  internal static let style: WindowStyle =
+  private static let style: WindowStyle =
       (base: DWORD(WS_BORDER | WS_TABSTOP | WS_VISIBLE), extended: 0)
 
   /// Configuring the Date Picker Style

--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -30,8 +30,8 @@
 import WinSDK
 
 public class Label: Control {
-  internal static let `class`: WindowClass = WindowClass(named: "STATIC")
-  internal static let style: WindowStyle =
+  private static let `class`: WindowClass = WindowClass(named: "STATIC")
+  private static let style: WindowStyle =
       (base: DWORD(WS_TABSTOP | WS_VISIBLE), extended: 0)
 
   private var _font: Font?

--- a/Sources/UI/ProgressView.swift
+++ b/Sources/UI/ProgressView.swift
@@ -30,8 +30,8 @@
 import WinSDK
 
 public class ProgressView: Control {
-  internal static let `class`: WindowClass = WindowClass(named: PROGRESS_CLASS)
-  internal static let style: WindowStyle = (base: DWORD(WS_VISIBLE), extended: 0)
+  private static let `class`: WindowClass = WindowClass(named: PROGRESS_CLASS)
+  private static let style: WindowStyle = (base: DWORD(WS_VISIBLE), extended: 0)
 
   public init(frame: Rect) {
     super.init(frame: frame, class: ProgressView.class, style: ProgressView.style)

--- a/Sources/UI/Slider.swift
+++ b/Sources/UI/Slider.swift
@@ -30,8 +30,8 @@
 import WinSDK
 
 public class Slider: Control {
-  internal static let `class`: WindowClass = WindowClass(named: TRACKBAR_CLASS)
-  internal static let style: WindowStyle =
+  private static let `class`: WindowClass = WindowClass(named: TRACKBAR_CLASS)
+  private static let style: WindowStyle =
       (base: DWORD(WS_VISIBLE | TBS_TRANSPARENTBKGND), extended: 0)
 
   public var value: Float {

--- a/Sources/UI/Switch.swift
+++ b/Sources/UI/Switch.swift
@@ -39,8 +39,8 @@ internal let SwiftSwitchProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 }
 
 public class Switch: Control {
-  internal static let `class`: WindowClass = WindowClass(named: "BUTTON")
-  internal static let style: WindowStyle =
+  private static let `class`: WindowClass = WindowClass(named: "BUTTON")
+  private static let style: WindowStyle =
       (base: DWORD(WS_TABSTOP | WS_VISIBLE | BS_CHECKBOX), extended: 0)
 
   /// Customizing the Appearance of the Switch

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -47,9 +47,10 @@ case justified
 }
 
 public class TextField: Control {
-  internal static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
-  internal static let style: WindowStyle =
-      (base: DWORD(WS_BORDER | WS_TABSTOP | WS_VISIBLE | ES_AUTOHSCROLL), extended: 0)
+  private static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
+  private static let style: WindowStyle =
+      (base: DWORD(WS_BORDER | WS_TABSTOP | WS_VISIBLE | ES_AUTOHSCROLL),
+       extended: 0)
 
   public weak var delegate: TextFieldDelegate?
 

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -38,9 +38,10 @@ internal let SwiftTextViewProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uI
 
 // FIXME(compnerd) we would like this to derive from ScrollView
 public class TextView: View {
-  internal static let `class`: WindowClass = WindowClass(named: "EDIT")
-  internal static let style: WindowStyle =
-      (base: DWORD(WS_BORDER | WS_HSCROLL | WS_TABSTOP | WS_VISIBLE | WS_VSCROLL | ES_MULTILINE), extended: 0)
+  private static let `class`: WindowClass = WindowClass(named: "EDIT")
+  private static let style: WindowStyle =
+      (base: DWORD(WS_BORDER | WS_HSCROLL | WS_TABSTOP | WS_VISIBLE | WS_VSCROLL | ES_MULTILINE),
+       extended: 0)
 
   public var editable: Bool {
     get {

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -76,12 +76,12 @@ internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 }
 
 public class Window: View {
-  internal static let `class`: WindowClass =
+  private static let `class`: WindowClass =
       WindowClass(hInst: GetModuleHandleW(nil), name: "Swift.Window",
                   style: UInt32(CS_HREDRAW | CS_VREDRAW),
                   hbrBackground: GetSysColorBrush(COLOR_3DFACE),
                   hCursor: LoadCursorW(nil, IDC_ARROW))
-  internal static let style: WindowStyle =
+  private static let style: WindowStyle =
       (base: DWORD(WS_OVERLAPPEDWINDOW | UInt32(WS_VISIBLE)), extended: 0)
 
   public weak var delegate: WindowDelegate?


### PR DESCRIPTION
These fields are meant to record the window class for the view and the
window style properties.  They are only used for construction and only
need to be accessed by the constructor.  Make them only accessible by
the type itself.