### PR TITLE
UI: remove `WM_PAINT` event from the `WindowDelegate`

### DIFF
--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -30,15 +30,10 @@
 import WinSDK
 
 public protocol WindowDelegate: class {
-  func OnPaint(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT
   func OnCommand(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT
 }
 
 public extension WindowDelegate {
-  func OnPaint(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT {
-    return 1
-  }
-
   func OnCommand(_ hWnd: HWND?, _ wParam: WPARAM, _ lParam: LPARAM) -> LRESULT {
     return 1
   }
@@ -47,10 +42,6 @@ public extension WindowDelegate {
 internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let window: Window? = unsafeBitCast(dwRefData, to: AnyObject.self) as? Window
   switch uMsg {
-  case UINT(WM_PAINT):
-    if window?.delegate?.OnPaint(hWnd, wParam, lParam) == 0 {
-      return 0
-    }
   case UINT(WM_DESTROY):
     // TODO(compnerd) we should handle multiple scenes, which can have multiple
     // Windows, so the destruction of a window should not post the quit message


### PR DESCRIPTION
The `WM_PAINT` event is not needed for clients, remove the event from
both the `WindowDelegate` protocol and the dispatch handling in the
subclass procedure.