### PR TITLE
Support: add additional logging levels

### DIFF
--- a/Sources/Support/Logging.swift
+++ b/Sources/Support/Logging.swift
@@ -35,12 +35,32 @@ internal let log: Logger = Logger(label: "org.compnerd.swift-win32")
 import WinSDK
 
 internal struct log {
+  static func trace(_ message: String) {
+    OutputDebugStringW("TRACE: \(message)\r\n".LPCWSTR)
+  }
+
+  static func debug(_ message: String) {
+    OutputDebugStringW("DEBUG: \(message)\r\n".LPCWSTR)
+  }
+
+  static func info(_ message: String) {
+    OutputDebugStringW("INFO: \(message)\r\n".LPCWSTR)
+  }
+
+  static func notice(_ message: String) {
+    OutputDebugStringW("NOTICE: \(message)\r\n".LPCWSTR)
+  }
+
   static func error(_ message: String) {
-    OutputDebugStringW("ERROR: \(message)".LPCWSTR)
+    OutputDebugStringW("ERROR: \(message)\r\n".LPCWSTR)
   }
 
   static func warning(_ message: String) {
-    OutputDebugStringW("WARNING: \(message)".LPCWSTR)
+    OutputDebugStringW("WARNING: \(message)\r\n".LPCWSTR)
+  }
+
+  static func critical(_ message: String) {
+    OutputDebugStringW("CRITICAL: \(message)\r\n".LPCWSTR)
   }
 }
 #endif


### PR DESCRIPTION
This covers the full levels that `swift-log` provides allowing for use
of additional logging levels even without `swift-log`.