### PR TITLE
Support: introduce Win32Font property wrapper

### DIFF
--- a/Sources/Support/PropertyWrappers.swift
+++ b/Sources/Support/PropertyWrappers.swift
@@ -65,3 +65,34 @@ public struct _Win32WindowText {
   public init() {
   }
 }
+
+@propertyWrapper
+public struct _Win32Font {
+  private var storage: Font?
+
+  public var wrappedValue: Font? {
+    get { fatalError() }
+    set { fatalError() }
+  }
+
+  public static subscript<EnclosingSelf: View>(_enclosingInstance view: EnclosingSelf,
+                                               wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Font?>,
+                                               storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, _Win32Font>)
+      -> Font? {
+    get {
+      guard view[keyPath: storageKeyPath].storage == nil else {
+        return view[keyPath: storageKeyPath].storage
+      }
+      let lResult: LRESULT = SendMessageW(view.hWnd, UINT(WM_GETFONT), 0, 0)
+      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
+    }
+    set(font) {
+      view[keyPath: storageKeyPath].storage = font
+      SendMessageW(view.hWnd, UINT(WM_SETFONT),
+                   unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
+    }
+  }
+
+  public init() {
+  }
+}

--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -33,19 +33,8 @@ public class Label: Control {
   private static let `class`: WindowClass = WindowClass(named: "STATIC")
   private static let style: WindowStyle = (base: DWORD(WS_TABSTOP), extended: 0)
 
-  private var _font: Font?
-  public var font: Font! {
-    get {
-      guard _font == nil else { return _font }
-      let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
-    }
-    set(font) {
-      self._font = font
-      SendMessageW(hWnd, UINT(WM_SETFONT),
-                   unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
-    }
-  }
+  @_Win32Font
+  public var font: Font!
 
   @_Win32WindowText
   public var text: String?

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -54,22 +54,12 @@ public class TextField: Control {
 
   public weak var delegate: TextFieldDelegate?
 
-  private var _font: Font?
-  public var font: Font? {
-    get {
-      guard _font == nil else { return _font }
-      let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
-    }
-    set(font) {
-      self._font = font
-      SendMessageW(hWnd, UINT(WM_SETFONT),
-                   unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
-    }
-  }
-
+  /// Accessing the Text Attributes
   @_Win32WindowText
   public var text: String?
+
+  @_Win32Font
+  public var font: Font?
 
   public var textAlignment: TextAlignment {
     get {

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -52,19 +52,8 @@ public class TextView: View {
     }
   }
 
-  private var _font: Font?
-  public var font: Font? {
-    get {
-      guard _font == nil else { return _font }
-      let lResult: LRESULT = SendMessageW(hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
-    }
-    set(font) {
-      self._font = font
-      SendMessageW(hWnd, UINT(WM_SETFONT),
-                   unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
-    }
-  }
+  @_Win32Font
+  public var font: Font?
 
   @_Win32WindowText
   public var text: String?


### PR DESCRIPTION
The window font property is very useful as it is used in a number of
places.  The font requires storage to persist the font handle while the
font remains in use.  However, the property itself is queried from the
window to ensure that the default values can be retrieved.