### PR TITLE
UI: remove helper constructor for `Button`

### DIFF
--- a/Examples/Calculator/Calculator.swift
+++ b/Examples/Calculator/Calculator.swift
@@ -45,6 +45,13 @@ private extension View {
   }
 }
 
+private extension Button {
+  convenience init(frame: Rect = .zero, title: String) {
+    self.init(frame: frame)
+    setTitle(title, forState: .normal)
+  }
+}
+
 private enum CalculatorOperation {
 case undefined
 case addition

--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -30,7 +30,14 @@
 import WinSDK
 import SwiftWin32
 
-internal extension Label {
+private extension Button {
+  convenience init(frame: Rect = .zero, title: String) {
+    self.init(frame: frame)
+    setTitle(title, forState: .normal)
+  }
+}
+
+private extension Label {
   convenience init(frame: Rect, title: String) {
     self.init(frame: frame)
     self.text = title

--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -81,10 +81,3 @@ public class Button: Control {
     SetWindowTextW(hWnd, title?.LPCWSTR)
   }
 }
-
-extension Button {
-  public convenience init(frame: Rect = .zero, title: String) {
-    self.init(frame: frame)
-    setTitle(title, forState: .normal)
-  }
-}


### PR DESCRIPTION
This helper was meant for the UICatalog and Calculator example programs.
Make them local to the examples.