### PR TITLE
UI: remove default value parameter for `init`

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -70,7 +70,7 @@ public class Button: Control {
 
   public weak var delegate: ButtonDelegate?
 
-  public init(frame: Rect = .default) {
+  public init(frame: Rect) {
     super.init(frame: frame, class: Button.class, style: Button.style)
     SetWindowSubclass(hWnd, SwiftButtonProc, UINT_PTR(1),
                       unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))

--- a/Sources/UI/DatePicker.swift
+++ b/Sources/UI/DatePicker.swift
@@ -55,7 +55,7 @@ public class DatePicker: Control {
     didSet { fatalError("not yet implemented") }
   }
 
-  public init(frame: Rect = .default) {
+  public init(frame: Rect) {
     super.init(frame: frame, class: DatePicker.class, style: DatePicker.style)
     SetWindowSubclass(hWnd, SwiftDatePickerProc, UINT_PTR(1),
                       unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))

--- a/Sources/UI/Switch.swift
+++ b/Sources/UI/Switch.swift
@@ -53,7 +53,7 @@ public class Switch: Control {
   }
   public private(set) var style: Switch.Style = .checkbox
 
-  public init(frame: Rect = .default) {
+  public init(frame: Rect) {
     super.init(frame: frame, class: Switch.class, style: Switch.style)
     SetWindowSubclass(hWnd, SwiftSwitchProc, UINT_PTR(1),
                       unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -108,7 +108,7 @@ public class TextField: Control {
     }
   }
 
-  public init(frame: Rect = .default) {
+  public init(frame: Rect) {
     super.init(frame: frame, class: TextField.class, style: TextField.style)
 
     // Remove the `WS_EX_CLIENTEDGE` which gives it a flat appearance

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -58,7 +58,7 @@ public class TextView: View {
   @_Win32WindowText
   public var text: String?
 
-  public init(frame: Rect = .default) {
+  public init(frame: Rect) {
     super.init(frame: frame, class: TextView.class, style: TextView.style)
 
     // Remove the `WS_EX_CLIENTEDGE` which gives it a flat appearance


### PR DESCRIPTION
Many of the older controls provided a default value for the
`init(frame:)` constructor.  Homogenise them to require the
parameter.