### PR TITLE
UI: introduce `ViewController`

### DIFF
--- a/Examples/Calculator/Calculator.swift
+++ b/Examples/Calculator/Calculator.swift
@@ -163,7 +163,7 @@ private class Calculator {
 
   private var window: Window =
       Window(frame: Rect(x: Double(CW_USEDEFAULT), y: Double(CW_USEDEFAULT),
-                         width: 204, height: 264), title: "Calculator")
+                         width: 204, height: 264))
 
   internal var txtResult: TextField =
       TextField(frame: Rect(x: 34, y: 32, width: 128, height: 24))
@@ -198,6 +198,8 @@ private class Calculator {
   public init() {
     self.delegate.calculator = self
 
+    self.window.rootViewController = ViewController()
+    self.window.rootViewController?.title = "Calculator"
     self.window.delegate = self.delegate
 
     self.window.addSubview(self.txtResult)

--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -56,7 +56,7 @@ class EventHandler: WindowDelegate {
 @main
 final class SwiftApplicationDelegate: ApplicationDelegate {
   var window: Window =
-      Window(frame: .default, title: "UICatalog")
+      Window(frame: .default)
 
   lazy var label: Label =
       Label(frame: Rect(x: 4.0, y: 12.0, width: 72.0, height: 16.0),
@@ -87,6 +87,9 @@ final class SwiftApplicationDelegate: ApplicationDelegate {
 
   func application(_: Application,
                    didFinishLaunchingWithOptions options: [Application.LaunchOptionsKey:Any]?) -> Bool {
+    window.rootViewController = ViewController()
+    window.rootViewController?.title = "UICatalog"
+
     window.addSubview(self.label)
     window.addSubview(self.button)
     window.addSubview(self.checkbox)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(SwiftWin32 SHARED
   UI/TraitCollection.swift
   UI/TraitEnvironment.swift
   UI/View.swift
+  UI/ViewController.swift
   UI/Window.swift
   UI/WindowClass.swift)
 target_sources(SwiftWin32 PRIVATE

--- a/Sources/UI/ViewController.swift
+++ b/Sources/UI/ViewController.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+import WinSDK
+
+public class ViewController {
+  /// Managing the View
+  public var view: View!
+
+  public var title: String? {
+    get {
+      let szLength: Int32 = GetWindowTextLengthW(view.hWnd)
+
+#if swift(<5.3)
+      let buffer: UnsafeMutablePointer<WCHAR> =
+        UnsafeMutablePointer<WCHAR>.allocate(capacity: Int(szLength) + 1)
+      defer { buffer.deallocate() }
+
+      GetWindowTextW(view.hWnd, buffer, szLength + 1)
+      return String(decodingCString: buffer, as: UTF16.self)
+#else
+      let buffer: [WCHAR] = Array<WCHAR>(unsafeUninitializedCapacity: Int(szLength) + 1) {
+        $1 = Int(GetWindowTextW(view.hWnd, $0.baseAddress!, CInt($0.count)))
+      }
+      return String(decodingCString: buffer, as: UTF16.self)
+#endif
+    }
+    set(value) {
+      SetWindowTextW(view.hWnd, value?.LPCWSTR)
+    }
+  }
+
+  public init() {
+  }
+}

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -75,7 +75,28 @@ public class Window: View {
   private static let style: WindowStyle =
       (base: DWORD(WS_OVERLAPPEDWINDOW | UInt32(WS_VISIBLE)), extended: 0)
 
+  // TODO(compnerd) remove this in favour of the view controller
   public weak var delegate: WindowDelegate?
+
+  /// Configuring the Window
+  public var rootViewController: ViewController? {
+    didSet { self.rootViewController?.view = self }
+  }
+
+  // TODO(compnerd) handle set
+  public private(set) var windowLevel: Window.Level = .normal
+
+  // TODO(compnerd) handle set
+  public private(set) var canResizeToFitContent: Bool = true
+
+  // TODO(compnerd) remove this in favour of scene management interface;
+  // windowScene provides the scene associated with the window, and the scene is
+  // attached to a window.
+  public var screen: Screen {
+    let hMonitor: HMONITOR =
+        MonitorFromWindow(hWnd, DWORD(MONITOR_DEFAULTTOPRIMARY))
+    return Screen.screens.filter { $0 == hMonitor }.first!
+  }
 
   /// Making Windows Key
   var isKeyWindow: Bool {
@@ -102,15 +123,6 @@ public class Window: View {
     // TODO(compnerd) post didResignKeyNotification
   }
 
-  // TODO(compnerd) remove this in favour of scene management interface;
-  // windowScene provides the scene associated with the window, and the scene is
-  // attached to a window.
-  public var screen: Screen {
-    let hMonitor: HMONITOR =
-        MonitorFromWindow(hWnd, DWORD(MONITOR_DEFAULTTOPRIMARY))
-    return Screen.screens.filter { $0 == hMonitor }.first!
-  }
-
   public init(frame: Rect) {
     super.init(frame: frame, class: Window.class, style: Window.style)
     SetWindowSubclass(hWnd, SwiftWindowProc, UINT_PTR(0),
@@ -122,8 +134,19 @@ public class Window: View {
 }
 
 extension Window {
-  public convenience init(frame: Rect = .zero, title: String) {
-    self.init(frame: frame)
-    SetWindowTextW(hWnd, title.LPCWSTR)
+  public struct Level: Equatable, Hashable, RawRepresentable {
+    public typealias RawValue = Double
+
+    public let rawValue: RawValue
+
+    public init(rawValue: RawValue) {
+      self.rawValue = rawValue
+    }
   }
+}
+
+extension Window.Level {
+  public static let normal: Window.Level = Window.Level(rawValue: 0.0)
+  public static let statusBar: Window.Level = Window.Level(rawValue: 1000.0)
+  public static let alert: Window.Level = Window.Level(rawValue: 2000.0)
 }


### PR DESCRIPTION
Introduce the new `ViewController` type that represents the controller
for a MVC pattern for the application.  This now allows us to remove the
extension for the window title as the title is now a property on the
associated controller for the window.