### PR TITLE
Support: remove `Rect.default`

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -30,6 +30,8 @@
 import WinSDK
 import SwiftWin32
 
+import let WinSDK.CW_USEDEFAULT
+
 private extension Button {
   convenience init(frame: Rect = .zero, title: String) {
     self.init(frame: frame)
@@ -56,7 +58,8 @@ class EventHandler: WindowDelegate {
 @main
 final class SwiftApplicationDelegate: ApplicationDelegate {
   var window: Window =
-      Window(frame: .default)
+      Window(frame: Rect(x: Double(CW_USEDEFAULT), y: Double(CW_USEDEFAULT),
+                         width: 444, height: 555))
 
   lazy var label: Label =
       Label(frame: Rect(x: 4.0, y: 12.0, width: 72.0, height: 16.0),

--- a/Sources/Support/Rect+UIExtensions.swift
+++ b/Sources/Support/Rect+UIExtensions.swift
@@ -29,12 +29,6 @@
 
 import WinSDK
 
-public extension Rect {
-  static let `default`: Rect =
-      Rect(x: Double(CW_USEDEFAULT), y: Double(CW_USEDEFAULT),
-           width: Double(CW_USEDEFAULT), height: Double(CW_USEDEFAULT))
-}
-
 internal extension Rect {
   init(from: RECT) {
     self.origin = Point(x: Double(from.left), y: Double(from.top))


### PR DESCRIPTION
This is not exactly usable as the height and width should be specified.
The other pattern that can be done is to create full-screen windows
using `Screen.default.bounds`.