### PR TITLE
Application: wire up `applicationWillTerminate(_)`

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -137,4 +137,8 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
   func applicationDidEnterBackground(_: Application) {
     print("Good night!")
   }
+
+  func applicationWillTerminate(_: Application) {
+    print("Goodbye cruel world!")
+  }
 }

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -132,6 +132,8 @@ public func ApplicationMain(_ argc: Int32,
     DispatchMessageW(&msg)
   }
 
+  Application.shared.delegate?.applicationWillTerminate(Application.shared)
+
   if let hMessageProcedureHook = hMessageProcedureHook {
     if !UnhookWindowsHookEx(hMessageProcedureHook) {
       log.error("UnhookWindowsHookEx(MsgProc): \(GetLastError())")


### PR DESCRIPTION
Send the `applicationWillTerminate` notification to the application
delegate before tearing down the process.