### PR TITLE
build: add an initial Package.swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 *~
 
 /build/
-
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let SwiftWin32 = Package(
+  name: "SwiftWin32",
+  products: [
+    .library(name: "SwiftWin32", type: .dynamic, targets: ["SwiftWin32"])
+  ],
+  targets: [
+    .target(name: "SwiftWin32",
+            path: "Sources",
+            exclude: [
+              "CMakeLists.txt",
+              "CWinRT",
+            ],
+            cSettings: [
+              .define("COBJMACROS"),
+              .define("NONAMELESSUNION"),
+            ],
+            linkerSettings: [
+              .linkedLibrary("User32"),
+              .linkedLibrary("ComCtl32"),
+            ]),
+  ]
+)


### PR DESCRIPTION
Using this package as a means to test the progress on
swift-package-manager port on Windows.  This allows building Swift/Win32
with swift-package-manager.