### PR TITLE
UI: sink `font` property to `View`

### DIFF
--- a/Sources/Support/PropertyWrappers.swift
+++ b/Sources/Support/PropertyWrappers.swift
@@ -65,34 +65,3 @@ public struct _Win32WindowText {
   public init() {
   }
 }
-
-@propertyWrapper
-public struct _Win32Font {
-  private var storage: Font?
-
-  public var wrappedValue: Font? {
-    get { fatalError() }
-    set { fatalError() }
-  }
-
-  public static subscript<EnclosingSelf: View>(_enclosingInstance view: EnclosingSelf,
-                                               wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Font?>,
-                                               storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, _Win32Font>)
-      -> Font? {
-    get {
-      guard view[keyPath: storageKeyPath].storage == nil else {
-        return view[keyPath: storageKeyPath].storage
-      }
-      let lResult: LRESULT = SendMessageW(view.hWnd, UINT(WM_GETFONT), 0, 0)
-      return Font(FontHandle(referencing: HFONT(bitPattern: Int(lResult))))
-    }
-    set(font) {
-      view[keyPath: storageKeyPath].storage = font
-      SendMessageW(view.hWnd, UINT(WM_SETFONT),
-                   unsafeBitCast(font?.hFont.value, to: WPARAM.self), LPARAM(1))
-    }
-  }
-
-  public init() {
-  }
-}

--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -33,8 +33,10 @@ public class Label: Control {
   private static let `class`: WindowClass = WindowClass(named: "STATIC")
   private static let style: WindowStyle = (base: DWORD(WS_TABSTOP), extended: 0)
 
-  @_Win32Font
-  public var font: Font!
+  public override var font: Font! {
+    get { return super.font }
+    set(value) { super.font = value }
+  }
 
   @_Win32WindowText
   public var text: String?

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -58,8 +58,10 @@ public class TextField: Control {
   @_Win32WindowText
   public var text: String?
 
-  @_Win32Font
-  public var font: Font?
+  public override var font: Font? {
+    get { return super.font }
+    set(value) { super.font = value }
+  }
 
   public var textAlignment: TextAlignment {
     get {

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -52,8 +52,10 @@ public class TextView: View {
     }
   }
 
-  @_Win32Font
-  public var font: Font?
+  public override var font: Font? {
+    get { return super.font }
+    set(value) { super.font = value }
+  }
 
   @_Win32WindowText
   public var text: String?

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -59,6 +59,14 @@ public class View {
   public private(set) var subviews: [View] = []
   public private(set) var superview: View?
 
+  internal var font: Font? {
+    didSet {
+      SendMessageW(self.hWnd, UINT(WM_SETFONT),
+                   unsafeBitCast(self.font?.hFont.value, to: WPARAM.self),
+                   LPARAM(1))
+    }
+  }
+
   /// Configuring a View's Visual Appearance
   public var isHidden: Bool {
     get { IsWindowVisible(self.hWnd) }


### PR DESCRIPTION
Make the `font` property a property of `View` rather than each control
implementing it.  Controls which expose control over the font can then
override the property and forward the `View` property which is limited
to `internal` access.

Furthermore simplify the property by making it a normal stored property
with a `didSet` observer.  This will become more useful as a subsequent
change will initialise the property always to ensure that the defaulted
font is the system font.