### PR TITLE
UI: wire up `.valueChanged` actions for `Stepper`

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -125,6 +125,9 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     self.slider.value = 48.0
 
     self.stepperLabel.text = String(Int(self.stepper.value))
+    self.stepper.addTarget(self,
+                           action: SwiftApplicationDelegate.stepperValueDidChange(_:),
+                           for: .valueChanged)
 
     window.makeKeyAndVisible()
 
@@ -146,5 +149,9 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
   private func pressMe(_: Button?) {
     MessageBoxW(nil, "Swift/Win32 Demo!".LPCWSTR,
                 "Swift/Win32 MessageBox!".LPCWSTR, UINT(MB_OK))
+  }
+
+  private func stepperValueDidChange(_ stepper: Stepper) {
+    self.stepperLabel.text = String(Int(stepper.value))
   }
 }

--- a/Sources/UI/Stepper.swift
+++ b/Sources/UI/Stepper.swift
@@ -29,6 +29,59 @@
 
 import WinSDK
 
+// Notification Proxy
+
+// When the Window is created, the initial parent is cached.  This cache cannot
+// be updated.  Instead, we always parent any stepper control to the
+// `Swift.Stepper.MessengerProxy` which is process-wide.  All notifications
+// about the control events will be dispatched by the proxy.
+//
+// In order to facilitate this, the control will stash the `self` (instance)
+// pointer in `GWLP_USERDATA`.  When we receive a `WM_HSCROLL` event, the
+// `lParam` contains the handle to the control.  We use this to query the
+// stashed instance pointer and dispatch the action to the control, allowing the
+// action targets to be invoked.
+
+private let SwiftStepperMessengerProc: WNDPROC = { (hWnd, uMsg, wParam, lParam) in
+  switch uMsg {
+  case UINT(WM_HSCROLL):
+    guard let hSender = HWND(bitPattern: UInt(lParam)) else { break }
+
+    let lpInstance = GetWindowLongPtrW(hSender, GWLP_USERDATA)
+    if lpInstance == 0 { break }
+
+    let stepper: Stepper! =
+        unsafeBitCast(lpInstance, to: AnyObject.self) as? Stepper
+    stepper.sendActions(for: .valueChanged)
+  default:
+    break
+  }
+
+  return DefWindowProcW(hWnd, uMsg, wParam, lParam)
+}
+
+private class StepperMessengerProxy {
+  private static let `class`: WindowClass =
+      WindowClass(hInst: GetModuleHandleW(nil),
+                  name: "Swift.Stepper.MessengerProxy",
+                  WindowProc: SwiftStepperMessengerProc)
+
+  fileprivate var hWnd: HWND!
+
+  fileprivate init() {
+    _ = StepperMessengerProxy.class.register()
+    self.hWnd = CreateWindowExW(0, StepperMessengerProxy.class.name, nil, 0,
+                                0, 0, 0, 0,
+                                HWND_MESSAGE, nil, GetModuleHandleW(nil), nil)!
+  }
+
+  deinit {
+    _ = DestroyWindow(self.hWnd)
+    _ = StepperMessengerProxy.class.unregister()
+  }
+}
+
+
 internal let SwiftStepperProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let stepper: Stepper? =
       unsafeBitCast(dwRefData, to: AnyObject.self) as? Stepper
@@ -39,6 +92,8 @@ public class Stepper: Control {
   private static let `class`: WindowClass = WindowClass(named: UPDOWN_CLASS)
   private static let style: WindowStyle =
       (base: UInt32(UDS_HORZ) | WS_POPUP | DWORD(WS_TABSTOP), extended: 0)
+
+  private static var proxy: StepperMessengerProxy = StepperMessengerProxy()
 
   /// Configuring the Stepper
   public var isContinuous: Bool { fatalError("not yet implemented") }
@@ -115,9 +170,13 @@ public class Stepper: Control {
   }
 
   public init(frame: Rect) {
-    super.init(frame: frame, class: Stepper.class, style: Stepper.style)
-    SetWindowSubclass(hWnd, SwiftStepperProc, UINT_PTR(1),
-                      unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
+    super.init(frame: frame, class: Stepper.class, style: Stepper.style,
+               parent: Stepper.proxy.hWnd)
+
+    _ = SetWindowLongPtrW(self.hWnd, GWLP_USERDATA,
+                          unsafeBitCast(self as AnyObject, to: LONG_PTR.self))
+    _ = SetWindowSubclass(self.hWnd, SwiftStepperProc, UINT_PTR(1),
+                          unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
 
     defer {
       self.wraps = false

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -84,7 +84,8 @@ public class View {
   /// Configuring the Bounds and Frame Rectangles
   public let frame: Rect
 
-  internal init(frame: Rect, `class`: WindowClass, style: WindowStyle) {
+  internal init(frame: Rect, `class`: WindowClass, style: WindowStyle,
+                parent: HWND? = nil) {
     self.window = (class: `class`, style: style)
     _ = self.window.class.register()
 
@@ -107,7 +108,7 @@ public class View {
                         Int32(bOverlappedWindow ? client.origin.y : 0),
                         Int32(client.size.width),
                         Int32(client.size.height),
-                        nil, nil, GetModuleHandleW(nil), nil)!
+                        parent, nil, GetModuleHandleW(nil), nil)!
 
     // If `CW_USEDEFAULT` was used, query the actual allocated rect
     if frame.origin.x == Double(CW_USEDEFAULT) ||


### PR DESCRIPTION
This creates the Stepper MessengerProxy to dispatch the notifications to
the control.  Add this into the `UICatalog` demo program as well.