### PR TITLE
UI: make subclass procedures `private`

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -29,7 +29,7 @@
 
 import WinSDK
 
-internal let SwiftButtonProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
+private let SwiftButtonProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let button: Button? = unsafeBitCast(dwRefData, to: AnyObject.self) as? Button
   switch uMsg {
   case UINT(WM_LBUTTONDOWN):

--- a/Sources/UI/DatePicker.swift
+++ b/Sources/UI/DatePicker.swift
@@ -29,7 +29,7 @@
 
 import WinSDK
 
-internal let SwiftDatePickerProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
+private let SwiftDatePickerProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let datepicker: DatePicker? =
       unsafeBitCast(dwRefData, to: AnyObject.self) as? DatePicker
   return DefSubclassProc(hWnd, uMsg, wParam, lParam)

--- a/Sources/UI/Stepper.swift
+++ b/Sources/UI/Stepper.swift
@@ -82,7 +82,7 @@ private class StepperMessengerProxy {
 }
 
 
-internal let SwiftStepperProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
+private let SwiftStepperProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let stepper: Stepper? =
       unsafeBitCast(dwRefData, to: AnyObject.self) as? Stepper
   return DefSubclassProc(hWnd, uMsg, wParam, lParam)

--- a/Sources/UI/Switch.swift
+++ b/Sources/UI/Switch.swift
@@ -29,7 +29,7 @@
 
 import WinSDK
 
-internal let SwiftSwitchProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
+private let SwiftSwitchProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let button: Switch? = unsafeBitCast(dwRefData, to: AnyObject.self) as? Switch
   switch uMsg {
   default:

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -30,7 +30,7 @@
 import WinSDK
 import Foundation
 
-internal let SwiftTextViewProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
+private let SwiftTextViewProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let textview: TextView? =
       unsafeBitCast(dwRefData, to: AnyObject.self) as? TextView
   return DefSubclassProc(hWnd, uMsg, wParam, lParam)

--- a/Sources/UI/Window.swift
+++ b/Sources/UI/Window.swift
@@ -39,7 +39,7 @@ public extension WindowDelegate {
   }
 }
 
-internal let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
+private let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let window: Window? = unsafeBitCast(dwRefData, to: AnyObject.self) as? Window
   switch uMsg {
   case UINT(WM_DESTROY):


### PR DESCRIPTION
These functions are referenced only from the subclass itself, it does
not need to be exposed to other sources.