### PR TITLE
UI: make `Button` conform to `Equatable`

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -57,3 +57,9 @@ public class Button: Control {
     SetWindowTextW(hWnd, title?.LPCWSTR)
   }
 }
+
+extension Button: Equatable {
+  public static func ==(_ lhs: Button, _ rhs: Button) -> Bool {
+    return lhs.hWnd == rhs.hWnd
+  }
+}


### PR DESCRIPTION
This allows for the comparison of `Button` to identify itself.