### PR TITLE
UI: make `View.hWnd` implicitly unwrapped

### DIFF
--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -52,7 +52,7 @@ private func ScaleClient(rect: inout Rect, for dpi: UINT, _ style: WindowStyle) 
 }
 
 public class View {
-  internal var hWnd: HWND
+  internal var hWnd: HWND!
   internal var window: (`class`: WindowClass, style: WindowStyle)
 
   // TODO(compnerd) handle set


### PR DESCRIPTION
We internally assume that the `hWnd` for the `View` is always valid.
The window should only be destroyed when the instance is being
deallocated.  As a result, the `hWnd` should always be non-nil.  This
previously caused issues as the `CreateWindowExW` would accidentally
return `nil` and we would not notice it the return type is marked as
nullable.