### PR TITLE
UI: initialize the default font

### DIFF
--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -135,6 +135,8 @@ public class View {
                  UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
 
     self.frame = client
+
+    defer { self.font = Font.systemFont(ofSize: Font.systemFontSize) }
   }
 
   deinit {


### PR DESCRIPTION
When constructing a view, always set the default font.  Although in some
cases this is meaningless (e.g. `Window`), it ensures that all controls
use the preferred system font of the default system font size.