### PR TITLE
Support: adjust `_Win32WindowText` property wrapper

### DIFF
--- a/Sources/Support/PropertyWrappers.swift
+++ b/Sources/Support/PropertyWrappers.swift
@@ -42,6 +42,7 @@ public struct _Win32WindowText {
       -> String? {
     get {
       let szLength: Int32 = GetWindowTextLengthW(view.hWnd)
+      guard szLength > 0 else { return nil }
 
 #if swift(<5.3)
       let buffer: UnsafeMutablePointer<WCHAR> =


### PR DESCRIPTION
Adjust the implementation to return nil if there is no text rather than
an empty string.  This enables differentiating between an empty string
and no text being set.