### PR TITLE
UI: add support for placeholder text in `TextField`

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -116,6 +116,7 @@ final class SwiftApplicationDelegate: ApplicationDelegate {
 
     self.password.isSecureTextEntry = true
     self.password.font = Font(name: "Cascadia Code", size: 10)
+    self.password.placeholder = "Password"
 
     self.textview.text = """
 Lorem ipsum dolor sit amet, consectetur adipiscicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
Since we model the `TextField` using a RichEdit, we cannot use the
simpler approach of using `EM_SETCUEBANNER` to render the placeholder
text.  Instead, rely on the fact that we subclass the window to override
the `WM_PAINT` event and render the placeholder text manually on top of
the default rendering.