### PR TITLE
build: split up `Application` and `UI` sources

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -3,7 +3,8 @@ add_subdirectory(CWinRT)
 add_library(SwiftWin32 SHARED
   Application/Application.swift
   Application/ApplicationDelegate.swift
-  Application/ApplicationMain.swift
+  Application/ApplicationMain.swift)
+target_sources(SwiftWin32 PRIVATE
   UI/AlertAction.swift
   UI/AlertController.swift
   UI/AnimationCurve.swift


### PR DESCRIPTION
This just categorises them better to be more homogeneous and easier to
follow.