### PR TITLE
UI: make `TraitCollection.current` a stored property

### DIFF
--- a/Sources/UI/TraitCollection.swift
+++ b/Sources/UI/TraitCollection.swift
@@ -193,15 +193,14 @@ private func GetCurrentLayoutDirection() -> TraitEnvironmentLayoutDirection {
 }
 
 public class TraitCollection {
-  public static var current: TraitCollection {
-    return TraitCollection(traitsFrom: [
-      TraitCollection(userInterfaceStyle: GetCurrentColorScheme()),
-      TraitCollection(userInterfaceIdiom: GetCurrentDeviceFamily()),
-      TraitCollection(userInterfaceLevel: GetCurrentElevationLevel()),
-      TraitCollection(layoutDirection: GetCurrentLayoutDirection()),
-      TraitCollection(accessibilityContrast: GetCurrentAccessibilityContrast()),
-    ])
-  }
+  public private(set) static var current: TraitCollection =
+      TraitCollection(traitsFrom: [
+        TraitCollection(userInterfaceStyle: GetCurrentColorScheme()),
+        TraitCollection(userInterfaceIdiom: GetCurrentDeviceFamily()),
+        TraitCollection(userInterfaceLevel: GetCurrentElevationLevel()),
+        TraitCollection(layoutDirection: GetCurrentLayoutDirection()),
+        TraitCollection(accessibilityContrast: GetCurrentAccessibilityContrast()),
+      ])
 
   // Retriving Size Class Traits
   public private(set) var horizontalSizeClass: UserInterfaceSizeClass =


### PR DESCRIPTION
Rather than re-computing the value each time, cache the value.  Although
this means that the value can be out-of-date, we should rely on Windows
notifications to update the traits as appropriate.