### PR TITLE
UI: explicit destroy the window when a `View` is deinited

### DIFF
--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -140,6 +140,7 @@ public class View {
   }
 
   deinit {
+    _ = DestroyWindow(self.hWnd)
     _ = self.window.class.unregister()
   }
 


### PR DESCRIPTION
This ensures that any windows that are not in use are cleaned up.
Although the need for this is unlikely common, it is better to ensure
that we do not leak any windows.