### PR TITLE
UI: use the constant for the Button Window Class

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -42,7 +42,7 @@ private let SwiftButtonProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSu
 }
 
 public class Button: Control {
-  private static let `class`: WindowClass = WindowClass(named: "BUTTON")
+  private static let `class`: WindowClass = WindowClass(named: WC_BUTTON)
   private static let style: WindowStyle =
       (base: DWORD(WS_TABSTOP | BS_PUSHBUTTON), extended: 0)
 


### PR DESCRIPTION
This avoids spelling out the button window class name.  Although this is
unlikely to change, it is better from a hygiene perspective.