### PR TITLE
UI: avoid spelling out the class names for `Switch` and `Label`

### DIFF
--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -30,7 +30,7 @@
 import WinSDK
 
 public class Label: Control {
-  private static let `class`: WindowClass = WindowClass(named: "STATIC")
+  private static let `class`: WindowClass = WindowClass(named: WC_STATIC)
   private static let style: WindowStyle = (base: DWORD(WS_TABSTOP), extended: 0)
 
   public override var font: Font! {

--- a/Sources/UI/Switch.swift
+++ b/Sources/UI/Switch.swift
@@ -39,7 +39,7 @@ private let SwiftSwitchProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSu
 }
 
 public class Switch: Control {
-  private static let `class`: WindowClass = WindowClass(named: "BUTTON")
+  private static let `class`: WindowClass = WindowClass(named: WC_BUTTON)
   private static let style: WindowStyle =
       (base: DWORD(WS_TABSTOP | BS_AUTOCHECKBOX), extended: 0)
 


### PR DESCRIPTION
This cleans up the last of the cases where we spelt out the names of the
window classes in the code base.  With the recent cleanups in the Swift
compiler, we no longer need these.