### PR TITLE
Support: remove redundant zero'ing

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -43,7 +43,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/Logging.swift
   Support/Rect+UIExtensions.swift
   Support/PropertyWrappers.swift
-  Support/String.swift
+  Support/String+UIExtensions.swift
   Support/WindowClass.swift
   Support/WindowsHandle.swift
   Support/WinSDK+Extensions.swift)

--- a/Sources/Support/String+UIExtensions.swift
+++ b/Sources/Support/String+UIExtensions.swift
@@ -31,12 +31,12 @@ import ucrt
 
 public extension String {
   var LPCWSTR: [UInt16] {
-    var array: [UInt16] =
-        Array<UInt16>(repeating: 0, count: self.utf16.count + 1)
-    _ = self.withCString(encodedAs: UTF16.self) {
-      wcscpy_s(&array, array.count, $0)
+    return self.withCString(encodedAs: UTF16.self) { buffer in
+      Array<UInt16>(unsafeUninitializedCapacity: self.utf16.count + 1) {
+        wcscpy_s($0.baseAddress, $0.count, buffer)
+        $1 = $0.count
+      }
     }
-    return array
   }
 }
 


### PR DESCRIPTION
Reduces the overhead of the conversion by avoiding the unnecessary
zero'ing.  Rename the file to indicate that this is adding extensions to
String.