### PR TITLE
Application: split out the LaunchOptionKeys and move main

### DIFF
--- a/Sources/Application/Application.swift
+++ b/Sources/Application/Application.swift
@@ -37,48 +37,6 @@ public class Application: Responder {
 }
 
 extension Application {
-  public struct LaunchOptionsKey: Equatable, Hashable, RawRepresentable {
-    public typealias RawValue = String
-
-    public var rawValue: RawValue
-
-    public init(rawValue: RawValue) {
-      self.rawValue = rawValue
-    }
-  }
-}
-
-extension Application.LaunchOptionsKey {
-  public static let annotation: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.Annotation")
-  public static let bluetootCentrals: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.BluetoothCentrals")
-  public static let bluetoothPeripherals: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.BluetoothPeripherals")
-  public static let cloudKitShareMetadata: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.CloudKitShareMetadata")
-  @available(*, deprecated)
-  public static let localNotification: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.LocalNotification")
-  public static let location: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.Location")
-  public static let newsstandDownloads: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.NewsStandDownloads")
-  public static let remoteNotification: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.RemoteNotification")
-  public static let shortcutItem: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.ShortCutItem")
-  public static let sourceApplication: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.SourceApplication")
-  public static let url: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.URL")
-  public static let userActivityDictionary: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.UserActivityDictionary")
-  public static let userActivityType: Application.LaunchOptionsKey =
-      Application.LaunchOptionsKey(rawValue: "Application.UserActivityType")
-}
-
-extension Application {
   /// The running states of the application
   public enum State: Int {
   /// The application is running in the foreground

--- a/Sources/Application/ApplicationDelegate.swift
+++ b/Sources/Application/ApplicationDelegate.swift
@@ -128,10 +128,3 @@ extension ApplicationDelegate {
     NSNotification.Name(rawValue: "UIApplicationWillTerminateNotification")
   }
 }
-
-extension ApplicationDelegate {
-  public static func main() {
-    ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil,
-                    String(describing: String(reflecting: Self.self)))
-  }
-}

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -82,7 +82,7 @@ public func ApplicationMain(_ argc: Int32,
 
   var hSwiftWin32: HMODULE?
   if !GetModuleHandleExW(DWORD(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT),
-                               "SwiftWin32.dll".LPCWSTR, &hSwiftWin32) {
+                         "SwiftWin32.dll".LPCWSTR, &hSwiftWin32) {
     log.error("GetModuleHandleExW: \(GetLastError())")
   }
 
@@ -125,4 +125,11 @@ public func ApplicationMain(_ argc: Int32,
   }
 
   return EXIT_SUCCESS
+}
+
+extension ApplicationDelegate {
+  public static func main() {
+    ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil,
+                    String(describing: String(reflecting: Self.self)))
+  }
 }

--- a/Sources/Application/LaunchKeyOptions.swift
+++ b/Sources/Application/LaunchKeyOptions.swift
@@ -1,0 +1,82 @@
+/**
+ * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+extension Application {
+  /// Keys used to access values in the launch options dictionary passed to your
+  /// application at initialization time.
+  public struct LaunchOptionsKey: Equatable, Hashable, RawRepresentable {
+    public typealias RawValue = String
+
+    public var rawValue: RawValue
+
+    public init(rawValue: RawValue) {
+      self.rawValue = rawValue
+    }
+  }
+}
+
+extension Application.LaunchOptionsKey {
+  /// A key indicating that the URL passed to your application contains custom
+  /// annotation data from the source application.
+  public static var annotation: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.Annotation")
+  }
+
+  /// A key indicating that the application was relaunched to handle
+  /// bluetooth-related events.
+  public static var bluetootCentrals: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.BluetoothCentrals")
+  }
+
+  /// A key indicating that the application should continue actions associated
+  /// with it's bluetooth peripheral objects.
+  public static var bluetoothPeripherals: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.BluetoothPeripherals")
+  }
+
+  /// A key indicating that the application was launched to handle an incoming
+  /// location event.
+  public static var location: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.Location")
+  }
+
+  /// A key indicating that a remove notification is available for the
+  /// application to process.
+  public static var remoteNotification: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.RemoteNotification")
+  }
+
+  /// A key indicating that the application was launched in response to the user
+  /// selecting a quick action.
+  public static var shortcutItem: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.ShortCutItem")
+  }
+
+  /// A key indicating that another application rrequested the launch of your
+  /// application.
+  public static let sourceApplication: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.SourceApplication")
+  }
+
+  /// A key indicating that the application was launched so it could open the
+  /// specified URL.
+  public static let url: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.URL")
+  }
+
+  /// A key indicating a dictionary associated with an activity that the user
+  /// wants to continue.
+  public static let userActivityDictionary: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.UserActivityDictionary")
+  }
+
+  /// A key indicating the type of user activity that the user wants to
+  /// continue.
+  public static let userActivityType: Application.LaunchOptionsKey {
+    Application.LaunchOptionsKey(rawValue: "Application.UserActivityType")
+  }
+}

--- a/Sources/Application/LaunchKeyOptions.swift
+++ b/Sources/Application/LaunchKeyOptions.swift
@@ -58,25 +58,25 @@ extension Application.LaunchOptionsKey {
 
   /// A key indicating that another application rrequested the launch of your
   /// application.
-  public static let sourceApplication: Application.LaunchOptionsKey {
+  public static var sourceApplication: Application.LaunchOptionsKey {
     Application.LaunchOptionsKey(rawValue: "Application.SourceApplication")
   }
 
   /// A key indicating that the application was launched so it could open the
   /// specified URL.
-  public static let url: Application.LaunchOptionsKey {
+  public static var url: Application.LaunchOptionsKey {
     Application.LaunchOptionsKey(rawValue: "Application.URL")
   }
 
   /// A key indicating a dictionary associated with an activity that the user
   /// wants to continue.
-  public static let userActivityDictionary: Application.LaunchOptionsKey {
+  public static var userActivityDictionary: Application.LaunchOptionsKey {
     Application.LaunchOptionsKey(rawValue: "Application.UserActivityDictionary")
   }
 
   /// A key indicating the type of user activity that the user wants to
   /// continue.
-  public static let userActivityType: Application.LaunchOptionsKey {
+  public static var userActivityType: Application.LaunchOptionsKey {
     Application.LaunchOptionsKey(rawValue: "Application.UserActivityType")
   }
 }

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(SwiftWin32 SHARED
   Application/Application.swift
   Application/ApplicationDelegate.swift
   Application/ApplicationMain.swift
-  Application/LaunchOptionsKey.swift)
+  Application/LaunchKeyOptions.swift)
 target_sources(SwiftWin32 PRIVATE
   UI/AlertAction.swift
   UI/AlertController.swift

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(SwiftWin32 SHARED
   Application/_TriviallyConstructible.swift
   Application/Application.swift
   Application/ApplicationDelegate.swift
-  Application/ApplicationMain.swift)
+  Application/ApplicationMain.swift
+  Application/LaunchOptionsKey.swift)
 target_sources(SwiftWin32 PRIVATE
   UI/AlertAction.swift
   UI/AlertController.swift


### PR DESCRIPTION
Restructure the files a bit to be easier to locate the code.  As the
application lifecycle code grows, this is important to aid with
discoverability of the code.