### PR TITLE
Application: wire up some of the Scene delegate callbacks

### DIFF
--- a/Sources/Application/Application.swift
+++ b/Sources/Application/Application.swift
@@ -7,13 +7,34 @@
 
 public class Application: Responder {
   /// Getting the App Instance
+
+  /// Returns the singleton application instance.
   public static var shared: Application = Application()
 
   /// Managing the App's Behaviour
+
+  /// The delegate of the application object.
   public var delegate: ApplicationDelegate?
 
   /// Getting the Application State
+
+  /// The applications current state or that of its most active scene.
   public internal(set) var state: Application.State
+
+  /// Getting Scene Information
+
+  /// A boolean indicating whether the application may display multiple scenes.
+  public var supportsMultipleScenes: Bool {
+    // TODO(compnerd) deserialise this from Info.plist in the bundle
+    false
+  }
+
+  /// The application's currently connected scenes.
+  public internal(set) var connectedScenes: Set<Scene> = []
+
+  /// The sessions whose scenes are either currently active or archived by the
+  /// system.
+  public internal(set) var openSessions: Set<SceneSession> = []
 
   /// Getting App Windows
   public internal(set) var keyWindow: Window?

--- a/Sources/Application/ApplicationDelegate.swift
+++ b/Sources/Application/ApplicationDelegate.swift
@@ -92,7 +92,7 @@ extension ApplicationDelegate {
   public func application(_ application: Application,
                           configurationForConnecting connectingSceneSession: SceneSession,
                           options: Scene.ConnectionOptions) -> SceneConfiguration {
-    return SceneConfiguration(name: "", sessionRole: connectingSceneSession.role)
+    return connectingSceneSession.configuration
   }
 
   public func application(_ application: Application,

--- a/Sources/UI/Scene.swift
+++ b/Sources/UI/Scene.swift
@@ -30,3 +30,14 @@ extension Scene {
     return NSNotification.Name(rawValue: "UISceneDidDisconnectNotification")
   }
 }
+
+extension Scene: Hashable {
+  public static func == (lhs: Scene, rhs: Scene) -> Bool {
+    // TODO(compnerd) figure out the proper equality check for Scene
+    return lhs === rhs
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    // TODO(compnerd) figure out the proper hashing for Scene
+  }
+}

--- a/Sources/UI/SceneConfiguration.swift
+++ b/Sources/UI/SceneConfiguration.swift
@@ -6,12 +6,22 @@
  **/
 
 public class SceneConfiguration {
+  /// Creating a Configuration Object
+
   /// Creates a scene-configuration object with the specified role and
   /// application-specific name.
   public init(name: String?, sessionRole: SceneSession.Role) {
     self.name = name
     self.role = sessionRole
   }
+
+  /// Specifying the Scene Creation Details
+
+  /// The class of the scene object you want to create.
+  public var sceneClass: AnyClass?
+
+  /// The class of the delegate object you want to create.
+  public var delegateClass: AnyClass?
 
   /// Getting the Configuration Attributes
 

--- a/Sources/UI/SceneSession.swift
+++ b/Sources/UI/SceneSession.swift
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import struct Foundation.UUID
-
 extension SceneSession {
   public struct Role: Equatable, Hashable, RawRepresentable {
     public typealias RawValue = String
@@ -22,19 +20,21 @@ extension SceneSession {
 extension SceneSession.Role {
   /// The scene displays noninteractive windows on an externally connected
   /// screen.
-  public static let windowApplication: SceneSession.Role =
-      SceneSession.Role(rawValue: "UIWindowSSceneSessionRoleApplication")
+  public static var windowApplication: SceneSession.Role {
+    SceneSession.Role(rawValue: "UIWindowSSceneSessionRoleApplication")
+  }
 
   /// The scene displays interactive content on the device's main screen.
-  public static let windowExternalDisplay: SceneSession.Role =
-      SceneSession.Role(rawValue: "UIWindowSceneSessionRoleExternalDisplay")
+  public static var windowExternalDisplay: SceneSession.Role {
+    SceneSession.Role(rawValue: "UIWindowSceneSessionRoleExternalDisplay")
+  }
 }
 
 public class SceneSession {
   /// Getting the Scene Information
 
   /// The scene associated with the current session.
-  public let scene: Scene?
+  public internal(set) weak var scene: Scene?
 
   /// The role played by the scene's content.
   public let role: SceneSession.Role
@@ -42,19 +42,20 @@ public class SceneSession {
   /// Getting the Scene Configuration Details
 
   /// The configuration data for creating the secene.
-  public var configuration: SceneConfiguration
+  // This is mutable as the configuration is only finalized after the deleate
+  // has formed the final configuration.
+  public internal(set) var configuration: SceneConfiguration
 
   /// Identifying the Scene
 
   /// A unique identifier that persists for the lifetime of the session
   public let persistentIdentifier: String
 
-  internal init(scene: Scene?, role: SceneSession.Role,
-                configuration: SceneConfiguration) {
-    self.scene = scene
+  internal init(identifier: String, role: SceneSession.Role,
+                configuration name: String) {
+    self.persistentIdentifier = identifier
     self.role = role
-    self.configuration = configuration
-    self.persistentIdentifier = UUID().uuidString
+    self.configuration = SceneConfiguration(name: name, sessionRole: role)
   }
 }
 


### PR DESCRIPTION
This allows round-tripping through the application delegate to get
configuration for the scenes.  This needs to be enhanced to permit
the client to modify the WindowScene's `sizeRestrictions` informing
the window construction to permit resizing.