### PR TITLE
UI: unrestrict window resizing for now

### DIFF
--- a/Sources/UI/WindowScene.swift
+++ b/Sources/UI/WindowScene.swift
@@ -8,4 +8,13 @@
 public class WindowScene: Scene {
   /// Getting the Interface Attributes
   public private(set) var sizeRestrictions: SceneSizeRestrictions?
+
+  public override init(session: SceneSession,
+                       connectionOptions: Scene.ConnectionOptions) {
+    // TODO(compnerd) we really should base this on the device properties.
+    // Windows Phone should have set the sizeRestrictions to nil.  Similarly,
+    // Surface Neo and Surface Duo Devices will not permit the window resizing.
+    self.sizeRestrictions = SceneSizeRestrictions()
+    super.init(session: session, connectionOptions: connectionOptions)
+  }
 }


### PR DESCRIPTION
Ideally this will be based on the device configuration.  Surface Neo and
Surface Duo devices should permit multiple windows via scenes, but
should restrict the window resizing.