### PR TITLE
Application: correct the order of callbacks

### DIFF
--- a/Sources/UI/Scene.swift
+++ b/Sources/UI/Scene.swift
@@ -16,7 +16,8 @@ extension Scene {
 public class Scene: Responder {
   /// Creating a Scene Object
 
-  public init(session: SceneSession, connectionOptions: Scene.ConnectionOptions) {
+  public required init(session: SceneSession,
+                       connectionOptions: Scene.ConnectionOptions) {
   }
 
   /// Managing the Life Cycle of a Scene

--- a/Sources/UI/SceneDelegate.swift
+++ b/Sources/UI/SceneDelegate.swift
@@ -7,10 +7,10 @@
 
 import WinSDK
 
-public protocol SceneDelegate {
+public protocol SceneDelegate: _TriviallyConstructible {
   /// Connecting and Disconnecting the Scene
 
-  /// Tells teh delegate about the addition of a scene to the application.
+  /// Tells the delegate about the addition of a scene to the application.
   func scene(_ scene: Scene, willConnecTo: SceneSession,
              options: Scene.ConnectionOptions)
 
@@ -19,7 +19,7 @@ public protocol SceneDelegate {
 }
 
 extension SceneDelegate {
-  public func scene(_ scene: Scene, willConnecTo: SceneSession,
+  public func scene(_ scene: Scene, willConnectTo: SceneSession,
                     options: Scene.ConnectionOptions) {
   }
 

--- a/Sources/UI/SceneSession.swift
+++ b/Sources/UI/SceneSession.swift
@@ -21,7 +21,7 @@ extension SceneSession.Role {
   /// The scene displays noninteractive windows on an externally connected
   /// screen.
   public static var windowApplication: SceneSession.Role {
-    SceneSession.Role(rawValue: "UIWindowSSceneSessionRoleApplication")
+    SceneSession.Role(rawValue: "UIWindowSceneSessionRoleApplication")
   }
 
   /// The scene displays interactive content on the device's main screen.

--- a/Sources/UI/WindowScene.swift
+++ b/Sources/UI/WindowScene.swift
@@ -9,7 +9,7 @@ public class WindowScene: Scene {
   /// Getting the Interface Attributes
   public private(set) var sizeRestrictions: SceneSizeRestrictions?
 
-  public override init(session: SceneSession,
+  public required init(session: SceneSession,
                        connectionOptions: Scene.ConnectionOptions) {
     // TODO(compnerd) we really should base this on the device properties.
     // Windows Phone should have set the sizeRestrictions to nil.  Similarly,


### PR DESCRIPTION
This corrects the startup events to make the scene setup later and
correct the extension points to execute at the right time to enable
applications to configure the scene.  It temporarily removes the
tear down path as it still does not seem to entirely make sense.  The
scene and scene delegate is now configurable via code.