### PR TITLE
Application: deserialise `SceneClass` and `SceneDelegate`

### DIFF
--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -108,13 +108,10 @@ public func ApplicationMain(_ argc: Int32,
   let options: Scene.ConnectionOptions = Scene.ConnectionOptions()
 
   // Setup the scene session.
-  // TODO(compnerd) deserialize configuration name from the application
-  // information.
   let (_, session) =
       Application.shared.openSessions
           .insert(SceneSession(identifier: UUID().uuidString,
-                               role: .windowApplication,
-                               configuration: "Default Configuration"))
+                               role: .windowApplication))
 
   // Update the scene configuration based on the delegate's response.
   if let configuration = Application.shared.delegate?

--- a/Sources/UI/SceneConfiguration.swift
+++ b/Sources/UI/SceneConfiguration.swift
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
+import func Foundation.NSClassFromString
+
 public class SceneConfiguration {
   /// Creating a Configuration Object
 
@@ -13,6 +15,36 @@ public class SceneConfiguration {
   public init(name: String?, sessionRole: SceneSession.Role) {
     self.name = name
     self.role = sessionRole
+
+    // Try to load the configuration from the Info.plist ...
+
+    // ... which requires that we have an Info.plist
+    guard let info = Application.shared.information else {
+      return
+    }
+
+    // ... which requires that the Info.plist contains scene configuration
+    guard let configurations =
+        info.scene?.configurations?[sessionRole.rawValue] else {
+      return
+    }
+
+    // ... taking the configuration which matches the name or the first entry
+    guard let scene = name == nil
+                        ? configurations.first
+                        : configurations.filter({ $0.name == name }).first else {
+      return
+    }
+
+    // ... deserialising the scene class if one was provided
+    if let sceneClass = scene.class {
+      self.sceneClass = NSClassFromString(sceneClass)
+    }
+
+    // .. deserialising the delegate class if one was provided
+    if let delegateClass = scene.delegate {
+      self.delegateClass = NSClassFromString(delegateClass)
+    }
   }
 
   /// Specifying the Scene Creation Details

--- a/Sources/UI/SceneSession.swift
+++ b/Sources/UI/SceneSession.swift
@@ -52,7 +52,7 @@ public class SceneSession {
   public let persistentIdentifier: String
 
   internal init(identifier: String, role: SceneSession.Role,
-                configuration name: String) {
+                configuration name: String? = nil) {
     self.persistentIdentifier = identifier
     self.role = role
     self.configuration = SceneConfiguration(name: name, sessionRole: role)


### PR DESCRIPTION
Deserialise the scene configuration from the Info.plist in the bundle.
Use this to deserialise `SceneClass` and `SceneDelegate` default values
when starting up the application.