### PR TITLE
Extract `View.gwlStyle` property

### DIFF
--- a/Sources/UI/Stepper.swift
+++ b/Sources/UI/Stepper.swift
@@ -77,12 +77,8 @@ public class Stepper: Control {
   public var isContinuous: Bool { fatalError("not yet implemented") }
   public var autorepeat: Bool { fatalError("not yet implemented") }
   public var wraps: Bool {
-    get { return GetWindowLongW(self.hWnd, GWL_STYLE) & UDS_WRAP == UDS_WRAP }
-    set {
-      var lStyle: LONG = GetWindowLongW(self.hWnd, GWL_STYLE)
-      lStyle = newValue ? lStyle | UDS_WRAP : lStyle & ~UDS_WRAP
-      _ = SetWindowLongW(self.hWnd, GWL_STYLE, lStyle)
-    }
+    get { self.GWL_STYLE & UDS_WRAP == UDS_WRAP }
+    set { self.GWL_STYLE = newValue ? self.GWL_STYLE | UDS_WRAP : self.GWL_STYLE & ~UDS_WRAP }
   }
   public var minimumValue: Double {
     get {

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -23,7 +23,7 @@ public class TextView: View {
 
   public var editable: Bool {
     get {
-      GetWindowLongW(hWnd, GWL_STYLE) & ES_READONLY == ES_READONLY
+      self.GWL_STYLE & ES_READONLY == ES_READONLY
     }
     set(editable) {
       SendMessageW(hWnd, UINT(EM_SETREADONLY), editable ? 0 : 1, 0)

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -33,6 +33,11 @@ public class View: Responder {
   internal var hWnd: HWND!
   internal var win32: (window: (`class`: WindowClass, style: WindowStyle), _: ())
 
+  internal var GWL_STYLE: LONG {
+    get { GetWindowLongW(hWnd, WinSDK.GWL_STYLE) }
+    set { SetWindowLongW(hWnd, WinSDK.GWL_STYLE, newValue) }
+  }
+
   internal var font: Font? {
     didSet {
       SendMessageW(self.hWnd, UINT(WM_SETFONT),
@@ -134,11 +139,11 @@ public class View: Responder {
       return
     }
 
-    if SetWindowLongPtrW(view.hWnd, GWL_STYLE,
+    if SetWindowLongPtrW(view.hWnd, WinSDK.GWL_STYLE,
                          LONG_PTR((view.win32.window.style.base & ~DWORD(WS_POPUP)) | DWORD(WS_CHILD))) == 0 {
       log.warning("SetWindowLongPtrW: \(GetLastError())")
       // TODO(compnerd) check for error
-      _ = SetWindowLongPtrW(view.hWnd, GWL_STYLE, LONG_PTR(view.win32.window.style.base))
+      _ = SetWindowLongPtrW(view.hWnd, WinSDK.GWL_STYLE, LONG_PTR(view.win32.window.style.base))
       return
     }
     view.win32.window.style.base = (view.win32.window.style.base & ~DWORD(WS_POPUP)) | DWORD(WS_CHILD)


### PR DESCRIPTION
Extracted from https://github.com/compnerd/swift-win32/pull/158.

I renamed the property into `gwlStyle` instead of `GWL_STYLE` to avoid clashing with the WinSDK constant, @compnerd please let me know if you still want it to be named in caps.