### PR TITLE
Properly install/remove hooks

### DIFF
--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -108,14 +108,16 @@ public func ApplicationMain(_ argc: Int32,
     log.error("GetModuleHandleExW: \(GetLastError())")
   }
 
+  let dwThreadId = GetCurrentThreadId()
+
   let hWindowProcedureHook: HHOOK? =
-      SetWindowsHookExW(WH_CALLWNDPROC, pApplicationWindowProc, hSwiftWin32, 0)
+      SetWindowsHookExW(WH_CALLWNDPROC, pApplicationWindowProc, hSwiftWin32, dwThreadId)
   if hWindowProcedureHook == nil {
     log.error("SetWindowsHookExW(WH_CALLWNDPROC): \(GetLastError())")
   }
 
   let hMessageProcedureHook: HHOOK? =
-      SetWindowsHookExW(WH_GETMESSAGE, pApplicationMessageProc, hSwiftWin32, 0)
+      SetWindowsHookExW(WH_GETMESSAGE, pApplicationMessageProc, hSwiftWin32, dwThreadId)
   if hMessageProcedureHook == nil {
     log.error("SetWindowsHookExW(WH_GETMESSAGE): \(GetLastError())")
   }

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -98,7 +98,7 @@ public func ApplicationMain(_ argc: Int32,
     log.error("SetWindowsHookExW(WH_CALLWNDPROC): \(GetLastError())")
   }
 
-  func removeHooks() {
+  defer {
     if let hWindowProcedureHook = hWindowProcedureHook {
       if !UnhookWindowsHookEx(hWindowProcedureHook) {
         log.error("UnhookWindowsHookEx(WndProc): \(GetLastError())")
@@ -109,7 +109,6 @@ public func ApplicationMain(_ argc: Int32,
   if Application.shared.delegate?
         .application(Application.shared,
                      didFinishLaunchingWithOptions: nil) == false {
-    removeHooks()
     return EXIT_FAILURE
   }
 
@@ -152,8 +151,6 @@ public func ApplicationMain(_ argc: Int32,
   }
 
   Application.shared.delegate?.applicationWillTerminate(Application.shared)
-
-  removeHooks()
 
   return EXIT_SUCCESS
 }

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -120,9 +120,24 @@ public func ApplicationMain(_ argc: Int32,
     log.error("SetWindowsHookExW(WH_GETMESSAGE): \(GetLastError())")
   }
 
+  func removeHooks() {
+    if let hMessageProcedureHook = hMessageProcedureHook {
+      if !UnhookWindowsHookEx(hMessageProcedureHook) {
+        log.error("UnhookWindowsHookEx(MsgProc): \(GetLastError())")
+      }
+    }
+
+    if let hWindowProcedureHook = hWindowProcedureHook {
+      if !UnhookWindowsHookEx(hWindowProcedureHook) {
+        log.error("UnhookWindowsHookEx(WndProc): \(GetLastError())")
+      }
+    }
+  }
+
   if Application.shared.delegate?
         .application(Application.shared,
                      didFinishLaunchingWithOptions: nil) == false {
+    removeHooks()
     return EXIT_FAILURE
   }
 
@@ -134,17 +149,7 @@ public func ApplicationMain(_ argc: Int32,
 
   Application.shared.delegate?.applicationWillTerminate(Application.shared)
 
-  if let hMessageProcedureHook = hMessageProcedureHook {
-    if !UnhookWindowsHookEx(hMessageProcedureHook) {
-      log.error("UnhookWindowsHookEx(MsgProc): \(GetLastError())")
-    }
-  }
-
-  if let hWindowProcedureHook = hWindowProcedureHook {
-    if !UnhookWindowsHookEx(hWindowProcedureHook) {
-      log.error("UnhookWindowsHookEx(WndProc): \(GetLastError())")
-    }
-  }
+  removeHooks()
 
   return EXIT_SUCCESS
 }

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -92,10 +92,8 @@ public func ApplicationMain(_ argc: Int32,
     log.error("GetModuleHandleExW: \(GetLastError())")
   }
 
-  let dwThreadId = GetCurrentThreadId()
-
   let hWindowProcedureHook: HHOOK? =
-      SetWindowsHookExW(WH_CALLWNDPROC, pApplicationWindowProc, hSwiftWin32, dwThreadId)
+      SetWindowsHookExW(WH_CALLWNDPROC, pApplicationWindowProc, hSwiftWin32, GetCurrentThreadId())
   if hWindowProcedureHook == nil {
     log.error("SetWindowsHookExW(WH_CALLWNDPROC): \(GetLastError())")
   }


### PR DESCRIPTION
Calling SetWindowsHookExW with 0 as thread id will load SwiftWin32.dll in all GUI processes, but UnhookWindowsHookEx does not guarantie to unload that library at all.
In my case, actualy, I got high CPU usage on many processes like Explorer.exe, and 100% CPU usage on user session after application (Calculator.exe) termination.
Better to pass the id of the main thread to SetWindowsHookExW and set hooks for the application that calls ApplicationMain