### PR TITLE
Support: split out the `WindowsHandle` extensions

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/String+UIExtensions.swift
   Support/WindowClass.swift
   Support/WindowsHandle.swift
+  Support/WindowsHandle+UIExtensions.swift
   Support/WinSDK+Extensions.swift)
 target_compile_options(SwiftWin32 PRIVATE
   "SHELL:-Xcc -DNONAMELESSUNION"

--- a/Sources/Support/WindowsHandle+UIExtensions.swift
+++ b/Sources/Support/WindowsHandle+UIExtensions.swift
@@ -1,0 +1,52 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+import WinSDK
+
+extension HFONT__: HandleValue {
+  typealias HandleType = HFONT
+  internal static func release(_ hFont: HandleType?) {
+    if let hFont = hFont {
+      DeleteObject(hFont)
+    }
+  }
+}
+
+internal typealias FontHandle = ManagedHandle<HFONT__>
+
+extension HDC__: HandleValue {
+  typealias HandleType = HDC
+  internal static func release(_ hDC: HandleType?) {
+    if let hDC = hDC {
+      DeleteDC(hDC)
+    }
+  }
+}
+
+internal typealias DeviceContextHandle = ManagedHandle<HDC__>

--- a/Sources/Support/WindowsHandle+UIExtensions.swift
+++ b/Sources/Support/WindowsHandle+UIExtensions.swift
@@ -2,29 +2,7 @@
  * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  **/
 
 import WinSDK

--- a/Sources/UI/Font.swift
+++ b/Sources/UI/Font.swift
@@ -7,17 +7,6 @@
 
 import WinSDK
 
-extension HFONT__: HandleValue {
-  typealias HandleType = HFONT
-  internal static func release(_ hFont: HandleType?) {
-    if let hFont = hFont {
-      DeleteObject(hFont)
-    }
-  }
-}
-
-internal typealias FontHandle = ManagedHandle<HFONT__>
-
 // Values derived from the Apple Human Inteface Guidelines
 // https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography
 private typealias TypographyInfo = (weight: Font.Weight, size: Double, leading: Int)

--- a/Sources/UI/Screen.swift
+++ b/Sources/UI/Screen.swift
@@ -31,17 +31,6 @@ extension DEVICE_SCALE_FACTOR {
   }
 }
 
-extension HDC__: HandleValue {
-  typealias HandleType = HDC
-  internal static func release(_ hDC: HandleType?) {
-    if let hDC = hDC {
-      DeleteDC(hDC)
-    }
-  }
-}
-
-internal typealias DeviceContextHandle = ManagedHandle<HDC__>
-
 public final class Screen {
   /// Returns the screen object representing the device's screen.
   public static var main: Screen { screens.first! }


### PR DESCRIPTION
This centralizes the definitions for the handling of Windows Handles to
make them easier to find.