### PR TITLE
Device: remove internal `landscape` alias (NFC)

### DIFF
--- a/Sources/UI/Device.swift
+++ b/Sources/UI/Device.swift
@@ -120,13 +120,13 @@ public struct Device {
     let bPortrait: Bool = dmDeviceMode.dmPelsWidth < dmDeviceMode.dmPelsHeight
     switch dmDeviceMode.u.s2.dmDisplayOrientation {
     case DWORD(DMDO_DEFAULT):
-      return bPortrait ? .portrait : .landscape
+      return bPortrait ? .portrait : .landscapeLeft
     case DWORD(DMDO_90):
       return bPortrait ? .landscapeRight : .portrait
     case DWORD(DMDO_180):
       return bPortrait ? .portraitUpsideDown : .landscapeRight
     case DWORD(DMDO_270):
-      return bPortrait ? .landscape : .portraitUpsideDown
+      return bPortrait ? .landscapeLeft : .portraitUpsideDown
     default:
       return .unknown
     }
@@ -244,6 +244,3 @@ extension Device {
       NSNotification.Name(rawValue: "UIDeviceProximityStateDidChangeNotification")
 }
 
-extension Device.Orientation {
-  internal static let landscape: Device.Orientation = .landscapeLeft
-}


### PR DESCRIPTION
Rather than creating an alternate name, use the well defined name
`landscapeLeft`.