### PR TITLE
Improve Application main loop

### DIFF
--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -148,12 +148,12 @@ public func ApplicationMain(_ argc: Int32,
 
   let mainRunLoop = RunLoop.current
 
-  var exitCode: Int32 = EXIT_SUCCESS
+  var nExitCode: Int32 = EXIT_SUCCESS
 
   mainLoop: while true {
     while PeekMessageW(&msg, nil, 0, 0, UINT(PM_REMOVE)) {
       guard msg.message != UINT(WM_QUIT) else {
-        exitCode = Int32(msg.wParam)
+        nExitCode = Int32(msg.wParam)
         break mainLoop
       }
 
@@ -174,7 +174,7 @@ public func ApplicationMain(_ argc: Int32,
 
   Application.shared.delegate?.applicationWillTerminate(Application.shared)
 
-  return exitCode
+  return nExitCode
 }
 
 extension ApplicationDelegate {

--- a/Sources/Support/WinSDK+Extensions.swift
+++ b/Sources/Support/WinSDK+Extensions.swift
@@ -75,13 +75,3 @@ func EnableMenuItem(_ hMenu: HMENU, _ uIDEnableItem: UINT, _ uEnable: UINT)
                     to: ((HMENU?, UINT, UINT) -> CInt).self)
   return pfnEnableMenuItem(hMenu, uIDEnableItem, uEnable)
 }
-
-// Wait next message with timeout
-func WaitMessage(_ dwMilliseconds: UINT) -> Bool {
-  let timerId = WinSDK.SetTimer(nil, 0, dwMilliseconds, nil)
-  defer {
-    WinSDK.KillTimer(nil, timerId)
-  }
-  // returned when a new message is placed in thread's message queue or timer expires
-  return WinSDK.WaitMessage()
-}

--- a/Sources/Support/WinSDK+Extensions.swift
+++ b/Sources/Support/WinSDK+Extensions.swift
@@ -78,9 +78,9 @@ func EnableMenuItem(_ hMenu: HMENU, _ uIDEnableItem: UINT, _ uEnable: UINT)
 
 // Wait next message with timeout
 func WaitMessage(_ dwMilliseconds: UINT) -> Bool {
-  let timerId = SetTimer(nil, 0, dwMilliseconds, nil)
+  let timerId = WinSDK.SetTimer(nil, 0, dwMilliseconds, nil)
   defer {
-    KillTimer(nil, timerId)
+    WinSDK.KillTimer(nil, timerId)
   }
-  return WaitMessage()
+  return WinSDK.WaitMessage()
 }

--- a/Sources/Support/WinSDK+Extensions.swift
+++ b/Sources/Support/WinSDK+Extensions.swift
@@ -75,3 +75,12 @@ func EnableMenuItem(_ hMenu: HMENU, _ uIDEnableItem: UINT, _ uEnable: UINT)
                     to: ((HMENU?, UINT, UINT) -> CInt).self)
   return pfnEnableMenuItem(hMenu, uIDEnableItem, uEnable)
 }
+
+// Wait next message with timeout
+func WaitMessage(_ dwMilliseconds: UINT) -> Bool {
+  let timerId = SetTimer(nil, 0, dwMilliseconds, nil)
+  defer {
+    KillTimer(nil, timerId)
+  }
+  return WaitMessage()
+}

--- a/Sources/Support/WinSDK+Extensions.swift
+++ b/Sources/Support/WinSDK+Extensions.swift
@@ -82,5 +82,6 @@ func WaitMessage(_ dwMilliseconds: UINT) -> Bool {
   defer {
     WinSDK.KillTimer(nil, timerId)
   }
+  // returned when a new message is placed in thread's message queue or timer expires
   return WinSDK.WaitMessage()
 }


### PR DESCRIPTION
These changes allow us to use the RunLoop timers/sources and/or the Dispatch queue API on the main queue.
In future we should use CFRunLoop API to handle Win32 messages
_CFRunLoopSetWindowsMessageQueueMas and _CFRunLoopSetWindowsMessageQueueHandler wrapped in Swift style API