### PR TITLE
UICatalog: adjust label height

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -61,7 +61,7 @@ final class SwiftApplicationDelegate: ApplicationDelegate {
       DatePicker(frame: Rect(x: 4.0, y: 254.0, width: 256.0, height: 32.0))
 
   lazy var stepperLabel: Label =
-      Label(frame: Rect(x: 4.0, y: 292.0, width: 128.0, height: 48.0))
+      Label(frame: Rect(x: 4.0, y: 292.0, width: 128.0, height: 32.0))
   lazy var stepper: Stepper =
       Stepper(frame: Rect(x: 197.0, y: 290.0, width: 64.0, height: 32.0))
 


### PR DESCRIPTION
The height of the label was greater than the stepper.  This would result
in a weird region of incorrect painting when adding a new control to the
demo.