### PR TITLE
git: add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.swift text eol=lf


### PR DESCRIPTION
Mark swift files as text and use Unix line endings.