### PR TITLE
Application: integrate RunLoop and Windows Message Loop

### DIFF
--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -144,11 +144,8 @@ public func ApplicationMain(_ argc: Int32,
     session.scene = scene
   }
 
-  var msg: MSG = MSG()
-  while GetMessageW(&msg, nil, 0, 0) > 0 {
-    TranslateMessage(&msg)
-    DispatchMessageW(&msg)
-  }
+  RunLoop.main._add(WindowsMessageLoopSource(), forMode: .default)
+  RunLoop.main.run()
 
   Application.shared.delegate?.applicationWillTerminate(Application.shared)
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/Logging.swift
   Support/Rect+UIExtensions.swift
   Support/PropertyWrappers.swift
+  Support/RunLoop+UIExtensions.swift
   Support/String+UIExtensions.swift
   Support/WindowClass.swift
   Support/WindowsHandle.swift

--- a/Sources/Support/RunLoop+UIExtensions.swift
+++ b/Sources/Support/RunLoop+UIExtensions.swift
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import WinSDK
+import Foundation
+
+internal class WindowsMessageLoopSource: RunLoop._Source {
+  private var observer: RunLoop._Observer?
+
+  override func didSchedule(in mode: RunLoop.Mode) {
+    self.observer = RunLoop.main._observe([.beforeSources]) { _ in
+      var msg: MSG = MSG()
+      if PeekMessageW(&msg, nil, 0, 0, UINT(PM_NOREMOVE | PM_NOYIELD)) {
+        self.signal()
+      }
+    }
+  }
+
+  override func didCancel(in mode: RunLoop.Mode) {
+    PostQuitMessage(0)
+  }
+
+  override func perform() {
+    var msg: MSG = MSG()
+    switch Int(GetMessageW(&msg, nil, 0, 0)) {
+    case -1:
+      log.error("GetMessageW: \(GetLastError())")
+
+    case 0:
+      assert(msg.message == UINT(WM_QUIT),
+             "GetMessageW returned 0 with non-WM_QUIT message")
+      RunLoop.main._stop()
+
+    default:
+      TranslateMessage(&msg)
+      DispatchMessageW(&msg)
+    }
+  }
+}


### PR DESCRIPTION
Use SPI to construct a custom event source for the Windows message loop
and integrate it into an instance of the main RunLoop.  This allows us
to use Foundation to pump the Windows message loop as well as the
dispatch queues.  With this, it is now possible to use dispatch to run
UI processing asynchronously without having to manually pump the
dispatch queue.