### PR TITLE
UI: remove unnecessary variable in table view processing

### DIFF
--- a/Sources/UI/TableView.swift
+++ b/Sources/UI/TableView.swift
@@ -140,14 +140,13 @@ public class TableView: View {
 
     _ = SendMessageW(self.hWnd, UINT(LB_RESETCONTENT), 0, 0)
 
-    var index = 0
     for section in 0 ..< dataSource.numberOfSections(in: self) {
       for row in 0 ..< dataSource.tableView(self, numberOfRowsInSection: section) {
         let cell = dataSource.tableView(self, cellForRowAt: IndexPath(row: row, section: section))
-        _ = SendMessageW(self.hWnd, UINT(LB_INSERTSTRING), WPARAM(index),
+        _ = SendMessageW(self.hWnd, UINT(LB_INSERTSTRING),
+                         WPARAM(bitPattern: -1),
                          unsafeBitCast(cell as AnyObject, to: LPARAM.self))
         addSubview(cell)
-        index = index + 1
       }
     }
   }


### PR DESCRIPTION
We can use the sentinel `-1` for the index to indicate that the item
should be added to the end.  This avoids the need for special counting
and will become more important once header and footer cells are
inserted.