### PR TITLE
Update uses of GetLastError() to be called within the win32 init of Error

### DIFF
--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -39,6 +39,16 @@ private let pApplicationWindowProc: HOOKPROC = { (nCode: Int32, wParam: WPARAM, 
   return CallNextHookEx(nil, nCode, wParam, lParam)
 }
 
+// Wait next message with timeout
+private func WaitMessage(_ dwMilliseconds: UINT) -> Bool {
+  let uIDEvent = WinSDK.SetTimer(nil, 0, dwMilliseconds, nil)
+  defer {
+    WinSDK.KillTimer(nil, uIDEvent)
+  }
+  // returned when a new message is placed in thread's message queue or timer expires
+  return WinSDK.WaitMessage()
+}
+
 @discardableResult
 public func ApplicationMain(_ argc: Int32,
                             _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>,
@@ -145,14 +155,42 @@ public func ApplicationMain(_ argc: Int32,
   }
 
   var msg: MSG = MSG()
-  while GetMessageW(&msg, nil, 0, 0) > 0 {
-    TranslateMessage(&msg)
-    DispatchMessageW(&msg)
+
+  let mainRunLoop = RunLoop.current
+
+  var nExitCode: Int32 = EXIT_SUCCESS
+
+  mainLoop: while true {
+    // Process all messages in thread's message queue, for GUI applications UI events must have high priority
+    while PeekMessageW(&msg, nil, 0, 0, UINT(PM_REMOVE)) {
+      guard msg.message != UINT(WM_QUIT) else {
+        // Handle WM_QUIT message, set application's exit code and terminate main loop
+        nExitCode = Int32(msg.wParam)
+        break mainLoop
+      }
+      // Dispatch received message
+      TranslateMessage(&msg)
+      DispatchMessageW(&msg)
+    }
+
+    var limitDate: Date? = nil
+    repeat {
+      // Execute Foundation.RunLoop once and determine the next time the timer fires
+      // At this point handles all Foundation.RunLoop timers, sources and Dispatch.DispatchQueue.main tasks
+      limitDate = mainRunLoop.limitDate(forMode: .default)
+      // If Foundation.RunLoop doesn't contain any timer or timer should not be running right now, we interrupt the current loop, otherwise go to the next iteration
+      guard let limitDate = limitDate, limitDate.timeIntervalSinceNow <= 0 else {
+        break
+      }
+    } while true
+    // Yields control to other threads
+    // If Foundation.RunLoop contain a timer to execute, we wait untill a new message is placed in thread's message queue or the timer must be fired, otherwise we proceed to the next iteration of mainLoop, using 0 as the wait timeout.
+    _ = WaitMessage(DWORD(limitDate?.timeIntervalSinceNow ?? 0 * 1000))
   }
 
   Application.shared.delegate?.applicationWillTerminate(Application.shared)
 
-  return EXIT_SUCCESS
+  return nExitCode
 }
 
 extension ApplicationDelegate {

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -46,7 +46,7 @@ public func ApplicationMain(_ argc: Int32,
                             _ delegate: String?) -> Int32 {
   let hRichEdit: HMODULE? = LoadLibraryW("msftedit.dll".LPCWSTR)
   if hRichEdit == nil {
-    log.error("unable to load `msftedit.dll`: \(GetLastError())")
+    log.error("unable to load `msftedit.dll`: \(Error(win32: GetLastError()))")
   }
 
   if let application = application {
@@ -72,7 +72,7 @@ public func ApplicationMain(_ argc: Int32,
 
   // Enable Per Monitor DPI Awareness
   if !SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) {
-    log.error("SetProcessDpiAwarenessContext: \(GetLastError())")
+    log.error("SetProcessDpiAwarenessContext: \(Error(win32: GetLastError()))")
   }
 
   let dwICC: DWORD = DWORD(ICC_BAR_CLASSES)
@@ -89,19 +89,19 @@ public func ApplicationMain(_ argc: Int32,
   var hSwiftWin32: HMODULE?
   if !GetModuleHandleExW(DWORD(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT),
                          "SwiftWin32.dll".LPCWSTR, &hSwiftWin32) {
-    log.error("GetModuleHandleExW: \(GetLastError())")
+    log.error("GetModuleHandleExW: \(Error(win32: GetLastError()))")
   }
 
   let hWindowProcedureHook: HHOOK? =
       SetWindowsHookExW(WH_CALLWNDPROC, pApplicationWindowProc, hSwiftWin32, GetCurrentThreadId())
   if hWindowProcedureHook == nil {
-    log.error("SetWindowsHookExW(WH_CALLWNDPROC): \(GetLastError())")
+    log.error("SetWindowsHookExW(WH_CALLWNDPROC): \(Error(win32: GetLastError()))")
   }
 
   defer {
     if let hWindowProcedureHook = hWindowProcedureHook {
       if !UnhookWindowsHookEx(hWindowProcedureHook) {
-        log.error("UnhookWindowsHookEx(WndProc): \(GetLastError())")
+        log.error("UnhookWindowsHookEx(WndProc): \(Error(win32: GetLastError()))")
       }
     }
   }

--- a/Sources/Support/BatteryMonitor.swift
+++ b/Sources/Support/BatteryMonitor.swift
@@ -75,7 +75,7 @@ internal struct BatteryMonitor {
     self.hWnd = CreateWindowExW(0, BatteryMonitor.class.name, nil, 0, 0, 0, 0, 0,
                                 HWND_MESSAGE, nil, GetModuleHandleW(nil), nil)
     guard let hWnd = self.hWnd else {
-      log.warning("CreateWindowExW: \(GetLastError())")
+      log.warning("CreateWindowExW: \(Error(win32: GetLastError()))")
       return
     }
 
@@ -87,7 +87,7 @@ internal struct BatteryMonitor {
         RegisterPowerSettingNotification(self.hWnd, &setting,
                                          DWORD(DEVICE_NOTIFY_WINDOW_HANDLE))
     if self.hBatteryStateNotification == nil {
-      log.warning("RegisterPowerSettingNotification: \(GetLastError())")
+      log.warning("RegisterPowerSettingNotification: \(Error(win32: GetLastError()))")
     }
   }
 }

--- a/Sources/UI/Device.swift
+++ b/Sources/UI/Device.swift
@@ -97,7 +97,7 @@ public struct Device {
     dmDeviceMode.dmSize = WORD(MemoryLayout<DEVMODEW>.size)
     dmDeviceMode.dmDriverExtra = 0
     if !EnumDisplaySettingsExW(nil, ENUM_CURRENT_SETTINGS, &dmDeviceMode, 0) {
-      log.warning("EnumDisplaySettingsExW: \(GetLastError())")
+      log.warning("EnumDisplaySettingsExW: \(Error(win32: GetLastError()))")
       return .unknown
     }
 
@@ -167,7 +167,7 @@ public struct Device {
 
     var status: SYSTEM_POWER_STATUS = SYSTEM_POWER_STATUS()
     guard GetSystemPowerStatus(&status) else {
-      log.warning("GetSystemPowerStatus: \(GetLastError())")
+      log.warning("GetSystemPowerStatus: \(Error(win32: GetLastError()))")
       return -1.0
     }
 
@@ -190,7 +190,7 @@ public struct Device {
 
     var status: SYSTEM_POWER_STATUS = SYSTEM_POWER_STATUS()
     guard GetSystemPowerStatus(&status) else {
-      log.warning("GetSystemPowerStatus: \(GetLastError())")
+      log.warning("GetSystemPowerStatus: \(Error(win32: GetLastError()))")
       return .unknown
     }
 

--- a/Sources/UI/Font.swift
+++ b/Sources/UI/Font.swift
@@ -224,7 +224,7 @@ public class Font {
 
     if GetObjectW(self.hFont.value, Int32(MemoryLayout<LOGFONTW>.size),
                   &lfFont) == 0 {
-      log.error("GetObjectW: \(GetLastError())")
+      log.error("GetObjectW: \(Error(win32: GetLastError()))")
       return self
     }
     lfFont.lfHeight = PointToLogical(fontSize)
@@ -363,7 +363,7 @@ public class Font {
 
     if GetObjectW(self.hFont.value, Int32(MemoryLayout<LOGFONTW>.size),
                   &lfFont) == 0 {
-      log.error("GetObjectW: \(GetLastError())")
+      log.error("GetObjectW: \(Error(win32: GetLastError()))")
       return ""
     }
 
@@ -385,7 +385,7 @@ public class Font {
 
     if GetObjectW(self.hFont.value, Int32(MemoryLayout<LOGFONTW>.size),
                   &lfFont) == 0 {
-      log.error("GetObjectW: \(GetLastError())")
+      log.error("GetObjectW: \(Error(win32: GetLastError()))")
       return 0.0
     }
 
@@ -401,7 +401,7 @@ public class Font {
 
     var metrics: TEXTMETRICW = TEXTMETRICW()
     if !GetTextMetricsW(hDC.value, &metrics) {
-      log.warning("GetTextMetricsW: \(GetLastError())")
+      log.warning("GetTextMetricsW: \(Error(win32: GetLastError()))")
       return 0.0
     }
     return Double(metrics.tmAscent)
@@ -416,7 +416,7 @@ public class Font {
 
     var metrics: TEXTMETRICW = TEXTMETRICW()
     if !GetTextMetricsW(hDC.value, &metrics) {
-      log.warning("GetTextMetricsW: \(GetLastError())")
+      log.warning("GetTextMetricsW: \(Error(win32: GetLastError()))")
       return 0.0
     }
     return Double(metrics.tmDescent)
@@ -430,7 +430,7 @@ public class Font {
 
     var metrics: TEXTMETRICW = TEXTMETRICW()
     if !GetTextMetricsW(hDC.value, &metrics) {
-      log.warning("GetTextMetricsW: \(GetLastError())")
+      log.warning("GetTextMetricsW: \(Error(win32: GetLastError()))")
       return 0.0
     }
     return Double(metrics.tmExternalLeading)
@@ -444,7 +444,7 @@ public class Font {
 
     var size: SIZE = SIZE()
     if !GetTextExtentPoint32W(hDC.value, "u{0048}".LPCWSTR, 1, &size) {
-      log.warning("GetTextExtentPoint32W: \(GetLastError())")
+      log.warning("GetTextExtentPoint32W: \(Error(win32: GetLastError()))")
       return 0.0
     }
     return Double(size.cy)
@@ -458,7 +458,7 @@ public class Font {
 
     var size: SIZE = SIZE()
     if !GetTextExtentPoint32W(hDC.value, "u{0078}".LPCWSTR, 1, &size) {
-      log.warning("GetTextExtentPoint32W: \(GetLastError())")
+      log.warning("GetTextExtentPoint32W: \(Error(win32: GetLastError()))")
       return 0.0
     }
     return Double(size.cy)

--- a/Sources/UI/TableView.swift
+++ b/Sources/UI/TableView.swift
@@ -140,14 +140,13 @@ public class TableView: View {
 
     _ = SendMessageW(self.hWnd, UINT(LB_RESETCONTENT), 0, 0)
 
-    var index = 0
     for section in 0 ..< dataSource.numberOfSections(in: self) {
       for row in 0 ..< dataSource.tableView(self, numberOfRowsInSection: section) {
         let cell = dataSource.tableView(self, cellForRowAt: IndexPath(row: row, section: section))
-        _ = SendMessageW(self.hWnd, UINT(LB_INSERTSTRING), WPARAM(index),
+        _ = SendMessageW(self.hWnd, UINT(LB_INSERTSTRING),
+                         WPARAM(bitPattern: -1),
                          unsafeBitCast(cell as AnyObject, to: LPARAM.self))
         addSubview(cell)
-        index = index + 1
       }
     }
   }

--- a/Sources/UI/TraitCollection.swift
+++ b/Sources/UI/TraitCollection.swift
@@ -138,7 +138,7 @@ private func GetCurrentAccessibilityContrast() -> AccessibilityContrast {
   var hcContrast: HIGHCONTRASTW = HIGHCONTRASTW()
   hcContrast.cbSize = UINT(MemoryLayout<HIGHCONTRASTW>.size)
   if !SystemParametersInfoW(UINT(SPI_GETHIGHCONTRAST), 0, &hcContrast, 0) {
-    log.error("SystemParametersInfoW: \(GetLastError())")
+    log.error("SystemParametersInfoW: \(Error(win32: GetLastError()))")
     return .unspecified
   }
   return Int32(hcContrast.dwFlags) & HCF_HIGHCONTRASTON == HCF_HIGHCONTRASTON
@@ -148,7 +148,7 @@ private func GetCurrentAccessibilityContrast() -> AccessibilityContrast {
 private func GetCurrentLayoutDirection() -> TraitEnvironmentLayoutDirection {
   var dwDefaultLayout: DWORD = 0
   if !GetProcessDefaultLayout(&dwDefaultLayout) {
-    log.error("GetProcessDefaultLayout: \(GetLastError())")
+    log.error("GetProcessDefaultLayout: \(Error(win32: GetLastError()))")
     return .unspecified
   }
   return dwDefaultLayout == LAYOUT_RTL ? .rightToLeft : .leftToRight

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -30,6 +30,13 @@ private func ScaleClient(rect: inout Rect, for dpi: UINT, _ style: WindowStyle) 
 }
 
 public class View: Responder {
+  private static let `class`: WindowClass =
+      WindowClass(hInst: GetModuleHandleW(nil), name: "Swift.View",
+                  style: UInt32(CS_HREDRAW | CS_VREDRAW),
+                  hbrBackground: GetSysColorBrush(COLOR_3DFACE),
+                  hCursor: LoadCursorW(nil, IDC_ARROW))
+  private static let style: WindowStyle = (base: 0, extended: 0)
+
   internal var hWnd: HWND!
   internal var win32: (window: (`class`: WindowClass, style: WindowStyle), _: ())
 
@@ -71,6 +78,13 @@ public class View: Responder {
                        CInt(self.frame.size.width), CInt(self.frame.size.height),
                        UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
     }
+  }
+
+  /// Creating a View Object
+
+  // FIXME(compnerd) should this be marked as a convenience initializer?
+  public convenience init(frame: Rect) {
+    self.init(frame: frame, class: View.class, style: View.style)
   }
 
   internal init(frame: Rect, `class`: WindowClass, style: WindowStyle,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,10 +50,10 @@ steps:
     modifyEnvironment: true
 
 - script: |
-    curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
-    curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
-    curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
-    curl -L "https://raw.githubusercontent.com/apple/swift/master/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
+    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
+    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
   displayName: Configure SDK
 
 - script: |


### PR DESCRIPTION
Updated calls to `GetLastError()` to use the Error Struct's `init(win32 error: DWORD)` to allow for more meaningful output with the Error Description.

Fixes #165 