### PR TITLE
UI: enable derived views to observe sub-view addition

### DIFF
--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -185,6 +185,15 @@ public class View: Responder {
 
     view.superview = self
     subviews.append(view)
+
+    // Notify any subclassed types for observation.
+    self.didAddSubview(view)
+  }
+
+  /// Observing View-Related Changes
+
+  /// Tells the view that a subview was added.
+  public func didAddSubview(_ subview: View) {
   }
 
   // Responder Chain


### PR DESCRIPTION
Hookup the observation hook for enabling subviews to observe the
additional of a subview.  This can be potentially useful for resizing
windows when new content is added.