### PR TITLE
UI: introduce the internal `GWL_EXSTYLE` property

### DIFF
--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -125,9 +125,7 @@ public class TextField: Control {
     super.init(frame: frame, class: TextField.class, style: TextField.style)
 
     // Remove the `WS_EX_CLIENTEDGE` which gives it a flat appearance
-    let lExtendedStyle: LONG = GetWindowLongW(self.hWnd, GWL_EXSTYLE);
-    _ = SetWindowLongW(self.hWnd, GWL_EXSTYLE,
-                       lExtendedStyle & ~WS_EX_CLIENTEDGE)
+    self.GWL_EXSTYLE &= ~WS_EX_CLIENTEDGE
 
     // Enable the advanced typography options unconditionally rather than only
     // in complex scripts and math mode.

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -42,11 +42,9 @@ public class TextView: View {
     super.init(frame: frame, class: TextView.class, style: TextView.style)
 
     // Remove the `WS_EX_CLIENTEDGE` which gives it a flat appearance
-    let lExtendedStyle: LONG = GetWindowLongW(hWnd, GWL_EXSTYLE);
-    SetWindowLongW(hWnd, GWL_EXSTYLE, lExtendedStyle & ~WS_EX_CLIENTEDGE)
-
-    SetWindowSubclass(hWnd, SwiftTextViewProc, UINT_PTR(1),
-                      unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
+    self.GWL_EXSTYLE &= ~WS_EX_CLIENTEDGE
+    _ = SetWindowSubclass(hWnd, SwiftTextViewProc, UINT_PTR(1),
+                          unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
   }
 
   public func scrollRangeToVisible(_ range: NSRange) {

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -41,8 +41,13 @@ public class View: Responder {
   internal var win32: (window: (`class`: WindowClass, style: WindowStyle), _: ())
 
   internal var GWL_STYLE: LONG {
-    get { GetWindowLongW(hWnd, WinSDK.GWL_STYLE) }
-    set { SetWindowLongW(hWnd, WinSDK.GWL_STYLE, newValue) }
+    get { GetWindowLongW(self.hWnd, WinSDK.GWL_STYLE) }
+    set { _ = SetWindowLongW(self.hWnd, WinSDK.GWL_STYLE, newValue) }
+  }
+
+  internal var GWL_EXSTYLE: LONG {
+    get { GetWindowLongW(self.hWnd, WinSDK.GWL_EXSTYLE) }
+    set { _ = SetWindowLongW(self.hWnd, WinSDK.GWL_EXSTYLE, newValue) }
   }
 
   internal var font: Font? {


### PR DESCRIPTION
This property represents the Window's `GWL_EXSTYLE` property, mirroring
the ease of access of `GWL_STYLE`.