### PR TITLE
UI: make `ViewController` conform to `Responder`

### DIFF
--- a/Sources/UI/ViewController.swift
+++ b/Sources/UI/ViewController.swift
@@ -7,7 +7,7 @@
 
 import WinSDK
 
-public class ViewController {
+public class ViewController: Responder {
   /// Managing the View
   public var view: View!
 
@@ -26,7 +26,12 @@ public class ViewController {
     }
   }
 
-  public init() {
+  override public init() {
+  }
+
+  // Responder Chain
+  override public var next: Responder? {
+    return view?.superview
   }
 }
 


### PR DESCRIPTION
This makes a `ViewController` a `Responder` to allow wiring up the
events up the chain from the control to the application.