### PR TITLE
UI: `View` conforms to `TraitEnvironment`, `ContentSizeCateogryAdjusting`

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(SwiftWin32 PRIVATE
   UI/Device.swift
   UI/EdgeInsets.swift
   UI/Font.swift
+  UI/FontMetrics.swift
   UI/Label.swift
   UI/ProgressView.swift
   UI/Responder.swift

--- a/Sources/UI/FontMetrics.swift
+++ b/Sources/UI/FontMetrics.swift
@@ -1,0 +1,52 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+public class FontMetrics {
+  /// Creating a Font Metrics Object
+
+  /// Creates a font metrics object for the specified text style.
+  public init (forTextStyle style: Font.TextStyle) {
+  }
+
+  /// The default font metrics object for content.
+  public static let `default`: FontMetrics = FontMetrics(forTextStyle: .body)
+
+  /// Creating Scaled Fonts
+
+  /// Returns a version of the specified font that adopts the current font
+  /// metrics.
+  public func scaledFont(for font: Font) -> Font {
+    return scaledFont(for: font, compatibleWith: nil)
+  }
+
+  /// Returns a version of the specified font that adopts the current font
+  /// metrics and suports the specified traitss.
+  public func scaledFont(for font: Font,
+                         compatibleWith traitCollection: TraitCollection?)
+      -> Font {
+    return scaledFont(for: font, maximumPointSize: Double.greatestFiniteMagnitude,
+                      compatibleWith: traitCollection)
+  }
+
+  /// Returns a version of the specified font that adopts the current font
+  /// metrics and is constrained to the specified maximum size.
+  public func scaledFont(for font: Font, maximumPointSize: Double) -> Font {
+    return scaledFont(for: font, maximumPointSize: maximumPointSize,
+                      compatibleWith: nil)
+  }
+
+  /// Returns a version of the specified font that adopts the current font
+  /// metrics and is constrained to the specified traits and size.
+  public func scaledFont(for font: Font, maximumPointSize: Double,
+                         compatibleWith traitCollection: TraitCollection?)
+      -> Font {
+    let traitCollection = traitCollection ?? TraitCollection.current
+    // TODO(compnerd) adjust the font size for the trait collection and cap the
+    // size.
+    fatalError("\(#function) not yet implemented")
+  }
+}

--- a/Sources/UI/Label.swift
+++ b/Sources/UI/Label.swift
@@ -25,6 +25,14 @@ public class Label: Control {
 
   // ContentSizeCategoryAdjusting
   public var adjustsFontForContentSizeCategory = false
+
+  // TraitEnvironment
+  override public func traitCollectionDidChange(_ previousTraitCollection: TraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard self.adjustsFontForContentSizeCategory else { return }
+    self.font = FontMetrics.default.scaledFont(for: self.font,
+                                               compatibleWith: traitCollection)
+  }
 }
 
 extension Label: ContentSizeCategoryAdjusting {

--- a/Sources/UI/TextField.swift
+++ b/Sources/UI/TextField.swift
@@ -138,6 +138,14 @@ public class TextField: Control {
 
   // ContentSizeCategoryAdjusting
   public var adjustsFontForContentSizeCategory = false
+
+  // TraitEnvironment
+  override public func traitCollectionDidChange(_ previousTraitCollection: TraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard self.adjustsFontForContentSizeCategory else { return }
+    self.font = FontMetrics.default.scaledFont(for: self.font!,
+                                               compatibleWith: traitCollection)
+  }
 }
 
 extension TextField: TextInputTraits {

--- a/Sources/UI/TextView.swift
+++ b/Sources/UI/TextView.swift
@@ -48,6 +48,14 @@ public class TextView: View {
 
   // ContentSizeCategoryAdjusting
   public var adjustsFontForContentSizeCategory = false
+
+  // TraitEnvironment
+  override public func traitCollectionDidChange(_ previousTraitCollection: TraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard self.adjustsFontForContentSizeCategory else { return }
+    self.font = FontMetrics.default.scaledFont(for: self.font!,
+                                               compatibleWith: traitCollection)
+  }
 }
 
 extension TextView: ContentSizeCategoryAdjusting {

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -244,4 +244,16 @@ public class View: Responder {
     if let window = self.window { return window }
     return Application.shared
   }
+
+  // Trait Environment
+  // NOTE: this must be in the class to permit deviced types to override the
+  // notification.
+  public func traitCollectionDidChange(_ previousTraitCollection: TraitCollection?) {
+  }
+}
+
+extension View: TraitEnvironment {
+  public var traitCollection: TraitCollection {
+    return self.window?.screen.traitCollection ?? TraitCollection.current
+  }
 }


### PR DESCRIPTION
…sting`

`View` should conform to `TraitEnvironment` since it is impacted by the
current device traits.  This also allows `Label`, `TextField`, and
`TextView` implement the `ContentSizeCategoryAdjusting` conformance by
being able to observe trait environment changes, enabling them to adjust
the font if necessary.  This requires the addition of `FontMetrics` to
perform the scaling.
`FontMetrics.scaledFont(for:maximumPointSize:compatibleWith:)` needs to
be implemented still and is left for future work.