### PR TITLE
UI: make `View` equatable

### DIFF
--- a/Sources/UI/Button.swift
+++ b/Sources/UI/Button.swift
@@ -35,9 +35,3 @@ public class Button: Control {
     SetWindowTextW(hWnd, title?.LPCWSTR)
   }
 }
-
-extension Button: Equatable {
-  public static func ==(_ lhs: Button, _ rhs: Button) -> Bool {
-    return lhs.hWnd == rhs.hWnd
-  }
-}

--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -252,6 +252,12 @@ public class View: Responder {
   }
 }
 
+extension View: Equatable {
+  public static func ==(_ lhs: View, _ rhs: View) -> Bool {
+    return lhs.hWnd == rhs.hWnd
+  }
+}
+
 extension View: TraitEnvironment {
   public var traitCollection: TraitCollection {
     return self.window?.screen.traitCollection ?? TraitCollection.current


### PR DESCRIPTION
Rather than making `Button` equatable, make all views equatable by
making `View` equatable.  This is safe to do as we check the underlying
`hWnd` as a means of checking equality.