### PR TITLE
UI: handle `WM_GETMINMAXINFO` in `Window`

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/IndexPath+UIExtensions.swift
   Support/Logging.swift
   Support/Rect+UIExtensions.swift
+  Support/Point+UIExtensions.swift
   Support/PropertyWrappers.swift
   Support/String+UIExtensions.swift
   Support/WindowClass.swift

--- a/Sources/Support/Point+UIExtensions.swift
+++ b/Sources/Support/Point+UIExtensions.swift
@@ -1,0 +1,32 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import WinSDK
+
+extension Point {
+  internal init(from: POINT) {
+    self.init(x: Double(from.x), y: Double(from.y))
+  }
+}
+
+extension POINT {
+  internal init(from: Point) {
+    self.init(x: LONG(from.x), y: LONG(from.y))
+  }
+}
+
+extension Size {
+  internal init(from: POINT) {
+    self.init(width: Double(from.x), height: Double(from.y))
+  }
+}
+
+extension POINT {
+  internal init(from: Size) {
+    self.init(x: LONG(from.width), y: LONG(from.height))
+  }
+}


### PR DESCRIPTION
By intercepting this in the subclass procedure for Window, we can
restrict the client area sizing.  This allows us to honour the window
size request from the application as specified by the scene delegate.

Note that the client area must be adjusted to the window area when
limiting the tracking size of the Window as otherwise, the non-client
area will eat into the window shrinking the available client area.