### PR TITLE
SwiftUIWin32: add initial attempt to build a UI DSL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let SwiftWin32 = Package(
   name: "SwiftWin32",
   products: [
     .library(name: "SwiftWin32", type: .dynamic, targets: ["SwiftWin32"]),
+    .library(name: "SwiftUIWin32", type: .dynamic, targets: ["SwiftUIWin32"]),
     .executable(name: "UICatalog", targets: ["UICatalog"]),
     .executable(name: "Calculator", targets: ["Calculator"]),
     .executable(name: "HelloWorld", targets: ["HelloWorld"]),
@@ -40,6 +41,13 @@ let SwiftWin32 = Package(
         .linkedLibrary("User32"),
         .linkedLibrary("ComCtl32"),
       ]
+    ),
+    .target(
+      name: "SwiftUIWin32",
+      dependencies: [
+        "SwiftWin32",
+      ],
+      path: "Sources/SwiftUIWin32"
     ),
     .target(
       name: "Calculator",

--- a/Sources/SwiftUIWin32/Application.swift
+++ b/Sources/SwiftUIWin32/Application.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import SwiftWin32
+
+/// A type that represents the structure and behaviour of an application.
+public protocol Application {
+  /// Implementing an Application
+
+  /// The type of scene representing the content of the application.
+  associatedtype Body: Scene
+
+  /// The content and behaviour of the application.
+  @SceneBuilder
+  var body: Self.Body { get }
+
+  /// Running an Application
+
+  /// Creates an instance of the application using the body as the content.
+  init()
+}
+
+extension Application {
+  /// Initializes and runs the application.
+  public static func main() {
+    ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil,
+                    String(describing: String(reflecting: Self.self)))
+  }
+}

--- a/Sources/SwiftUIWin32/EmptyView.swift
+++ b/Sources/SwiftUIWin32/EmptyView.swift
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+@frozen
+public struct EmptyView: View {
+  public typealias Body = Never
+
+  public var body: Self.Body {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  @inlinable
+  public init() {
+  }
+}

--- a/Sources/SwiftUIWin32/Never+SwiftUI.swift
+++ b/Sources/SwiftUIWin32/Never+SwiftUI.swift
@@ -1,0 +1,20 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+extension Never: View {
+}
+
+extension Never: Scene {
+}
+
+extension Never {
+  public typealias Body = Never
+
+  public var body: Never {
+    fatalError("\(#function) not yet implemented")
+  }
+}

--- a/Sources/SwiftUIWin32/Scene.swift
+++ b/Sources/SwiftUIWin32/Scene.swift
@@ -1,0 +1,18 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// A part of the application's user interface.
+public protocol Scene {
+  /// Creating a Scene
+
+  /// The type of scene representing the body of this scene.
+  associatedtype Body: Scene
+
+  /// The content and behaviour of the scene.
+  @SceneBuilder
+  var body: Self.Body { get }
+}

--- a/Sources/SwiftUIWin32/SceneBuilder.swift
+++ b/Sources/SwiftUIWin32/SceneBuilder.swift
@@ -1,0 +1,13 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+@resultBuilder
+public struct SceneBuilder {
+  public static func buildBlock<Content: Scene>(_ content: Content) -> Content {
+    fatalError("\(#function) not yet implemented")
+  }
+}

--- a/Sources/SwiftUIWin32/View.swift
+++ b/Sources/SwiftUIWin32/View.swift
@@ -1,0 +1,13 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+public protocol View {
+  associatedtype Body: View
+
+  @ViewBuilder
+  var body: Self.Body { get }
+}

--- a/Sources/SwiftUIWin32/ViewBuilder.swift
+++ b/Sources/SwiftUIWin32/ViewBuilder.swift
@@ -1,0 +1,17 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+@resultBuilder
+public struct ViewBuilder {
+  public static func buildBlock() -> EmptyView {
+    return EmptyView()
+  }
+
+  public static func buildBlock<Content: View>(_ content: Content) -> Content {
+    fatalError("\(#function) not yet implemented")
+  }
+}

--- a/Sources/SwiftUIWin32/WindowGroup.swift
+++ b/Sources/SwiftUIWin32/WindowGroup.swift
@@ -1,0 +1,17 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+public struct WindowGroup<Content: View>: Scene {
+  public var body: some Scene {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  /// Creating a Window Group
+
+  public init(@ViewBuilder content: () -> Content) {
+  }
+}


### PR DESCRIPTION
Add some of the SwiftUI-like DSL building structuring for sketching out
a possible implementing of a DSL based UI construction layer built atop
of Swift/Win32.