### PR TITLE
Application: use an address to identify SwiftWin32

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let SwiftWin32 = Package(
       ],
       swiftSettings: [
         .define("WITH_SWIFT_LOG"),
+        .unsafeFlags(["-Xfrontend", "-validate-tbd-against-ir=none"]),
       ],
       linkerSettings: [
         .linkedLibrary("User32"),

--- a/Sources/Application/ApplicationMain.swift
+++ b/Sources/Application/ApplicationMain.swift
@@ -99,8 +99,10 @@ public func ApplicationMain(_ argc: Int32,
   InitCommonControlsEx(&ICCE)
 
   var hSwiftWin32: HMODULE?
-  if !GetModuleHandleExW(DWORD(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT),
-                         "SwiftWin32.dll".LPCWSTR, &hSwiftWin32) {
+  let dwFlags: DWORD = DWORD(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT)
+                     | DWORD(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS)
+  if !GetModuleHandleExW(dwFlags, #dsohandle.assumingMemoryBound(to: WCHAR.self),
+                         &hSwiftWin32) {
     log.error("GetModuleHandleExW: \(Error(win32: GetLastError()))")
   }
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/WindowsHandle+UIExtensions.swift
   Support/WinSDK+Extensions.swift)
 target_compile_options(SwiftWin32 PRIVATE
+  "SHELL:-Xfrontend -validate-tbd-against-ir=none"
   "SHELL:-Xcc -DNONAMELESSUNION"
   "SHELL:-Xcc -DCOBJMACROS")
 target_link_libraries(SwiftWin32 PUBLIC


### PR DESCRIPTION
Use the address of a variable within the module to identify the module
via the `GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS`.  This is more
reliable, and enables the library to be used in both static and dynamic
form.