### PR TITLE
UI: always scale the view for the DPI

### DIFF
--- a/Sources/UI/View.swift
+++ b/Sources/UI/View.swift
@@ -92,9 +92,15 @@ public class View: Responder {
   /// superview's coordinate system.
   public var frame: Rect {
     didSet {
+      // Scale window for DPI
+      var client: Rect = self.frame
+      ScaleClient(rect: &client, for: GetDpiForWindow(self.hWnd),
+                  self.win32.window.style)
+
+      // Resize and Position the Window
       _ = SetWindowPos(self.hWnd, nil,
-                       CInt(self.frame.origin.x), CInt(self.frame.origin.y),
-                       CInt(self.frame.size.width), CInt(self.frame.size.height),
+                       CInt(client.origin.x), CInt(client.origin.y),
+                       CInt(client.size.width), CInt(client.size.height),
                        UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
     }
   }


### PR DESCRIPTION
This ensures that when the size of a view is changed, we scale it
properly rather than keeping it at 100% on a HiDPI display with a
different scale.