### PR TITLE
UI: correct signature for `ContextMenuConfiguration.init(identifier:p…

### DIFF
--- a/Sources/UI/ContextMenuConfiguration.swift
+++ b/Sources/UI/ContextMenuConfiguration.swift
@@ -31,7 +31,7 @@ public class ContextMenuConfiguration {
 
   private init(identifier: NSCopying,
                previewProvider: @escaping ContextMenuContentPreviewProvider,
-               actionProvider: @escaping ContextMenuActionProvider) {
+               actionProvider: ContextMenuActionProvider?) {
     self.identifier = identifier
     self.previewProvider = previewProvider
     self.actionProvider = actionProvider


### PR DESCRIPTION
…reviewProvider:actionProvider:)`

The signature for the private initializer was incorrect resulting in an
infinite loop in the constructor that the compiler identified.  Correct
the signature to both silence the warning and to correct the
implementation