### PR TITLE
UI: add protocols for Configuration States

### DIFF
--- a/Sources/UI/CellConfigurationState.swift
+++ b/Sources/UI/CellConfigurationState.swift
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// A structure that encapsulates a cell's state.
+public struct CellConfigurationState: ConfigurationState {
+  // MARK - Managing View Configuration States
+
+  /// The traits that describe the current layout environment of the view, such
+  /// as the user interface style and layout direction.
+  public var traitCollection: TraitCollection
+
+  /// A boolean value that indicates whether the cell is in a selected state.
+  public var isSelected: Bool = false
+
+  /// A boolean value that indicates whether the cell is in a highlighted state.
+  public var isHighlighted: Bool = false
+
+  /// A boolean value that indicates whether the cell is in a focused state.
+  public var isFocused: Bool = false
+
+  /// A boolean value that indicates whether the cell is in a disabled state.
+  public var isDisabled: Bool = false
+
+  /// Accesses custom states by key.
+  public subscript(key: ConfigurationStateCustomKey) -> AnyHashable? {
+    get { return nil }
+    set { }
+  }
+
+  // MARK - Creating a Configuration State Manually
+
+  /// Creates a cell configuration state with the specified trait collection.
+  public init(traitCollection: TraitCollection) {
+    self.traitCollection = traitCollection
+  }
+}

--- a/Sources/UI/ConfigurationState.swift
+++ b/Sources/UI/ConfigurationState.swift
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// A key that defines a custom state for a view.
+public struct ConfigurationStateCustomKey: Equatable, Hashable, RawRepresentable {
+  public typealias RawValue = String
+
+  public let rawValue: RawValue
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+}
+
+extension ConfigurationStateCustomKey {
+  public init(_ rawValue: String) {
+    self.rawValue = rawValue
+  }
+}
+
+/// The requirements for an object that encapsulate a view's state.
+public protocol ConfigurationState {
+  // MARK - Managing Configuration States
+
+  /// The traits that describe the current layout environment of the view, such
+  /// as the user interface style and layout direction.
+  var traitCollection: TraitCollection { get set }
+
+  /// Accesses custom states by key.
+  subscript(key: ConfigurationStateCustomKey) -> AnyHashable? { get set }
+
+  // MARK - Creating a Configuration State Manually
+
+  /// Creates a View configuration state with the specified trait collection.
+  init(traitCollection: TraitCollection)
+}


### PR DESCRIPTION
Add the basis for the definitions for the configuration states needed to
build the content configurations for list views which will allow
extending the table view.