### PR TITLE
UI: support showing basic context menus

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -25,7 +25,10 @@ target_sources(SwiftWin32 PRIVATE
   UI/ContentSizeCategoryAdjusting.swift
   UI/ContentSizeCategoryImageAdjusting.swift
   UI/ContextMenuConfiguration.swift
+  UI/ContextMenuInteraction.swift
   UI/ContextMenuInteractionAnimating.swift
+  UI/ContextMenuInteractionCommitAnimating.swift
+  UI/ContextMenuInteractionDelegate.swift
   UI/Control.swift
   UI/CoordinateSpace.swift
   UI/DatePicker.swift

--- a/Sources/SwiftWin32/Support/WindowsHandle+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/WindowsHandle+UIExtensions.swift
@@ -38,3 +38,14 @@ extension HBITMAP__: HandleValue {
   }
 }
 internal typealias BitmapHandle = ManagedHandle<HBITMAP__>
+
+extension HMENU: HandleValue {
+  typealias HandleType = HMENU
+  internal static func release(_ hMenu: HandleType?) {
+    if let hMenu = hMenu {
+      DestroyMenu(hMenu)
+    }
+  }
+}
+
+internal typealias MenuHandle = ManagedHandle<HMENU>

--- a/Sources/SwiftWin32/UI/ContextMenuConfiguration.swift
+++ b/Sources/SwiftWin32/UI/ContextMenuConfiguration.swift
@@ -44,4 +44,8 @@ public class ContextMenuConfiguration {
 
   private var previewProvider: ContextMenuContentPreviewProvider
   private var actionProvider: ContextMenuActionProvider?
+
+  internal func provideActions() -> Menu? {
+    actionProvider?([]) // TODO suggest default actions
+  }
 }

--- a/Sources/SwiftWin32/UI/ContextMenuInteraction.swift
+++ b/Sources/SwiftWin32/UI/ContextMenuInteraction.swift
@@ -19,7 +19,7 @@ extension ContextMenuInteraction {
   }
 }
 
-public class ContextMenuInteraction {
+public class ContextMenuInteraction: Interaction {
   // MARK - Creating a Context Menu Interaction Object
 
   /// Creates a context menu interaction object with the specified delegate
@@ -33,6 +33,14 @@ public class ContextMenuInteraction {
   /// The object that provides the preview and contextual menu for your content
   /// and responds to interaction-related events.
   public private(set) weak var delegate: ContextMenuInteractionDelegate?
+
+  public private(set) var view: View? = nil
+
+  public func willMove(to view: View?) { }
+
+  public func didMove(to view: View?) {
+    self.view = view
+  }
 
   // MARK - Getting the Interaction's Location
 

--- a/Sources/SwiftWin32/UI/Menu.swift
+++ b/Sources/SwiftWin32/UI/Menu.swift
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
+import WinSDK
+
 extension Menu {
   /// Constants for identifying an application's standard menus.
   public struct Identifier: Equatable, Hashable, RawRepresentable {
@@ -275,12 +277,30 @@ extension Menu.Options {
 /// A container for grouping related menu elements in an application menu or
 /// contextual menu.
 public class Menu: MenuElement {
+  internal let children: [MenuElement]
+
   /// Creating a Menu Object
 
   /// Creates a new menu with the specified values.
   public init(title: String = "", image: Image? = nil,
               identifier: Menu.Identifier? = nil, options: Menu.Options = [],
               children: [MenuElement] = []) {
+    self.children = children
     super.init(title: title, image: image)
+  }
+}
+
+internal struct Win32Menu {
+  internal let hMenu: MenuHandle
+  private let children: [Win32MenuElement]
+
+  internal init(_ hMenu: MenuHandle, children: [MenuElement]) {
+    self.hMenu = hMenu
+    self.children = children.map { Win32MenuElement.of($0) }
+    for (index, child) in self.children.enumerated() {
+      InsertMenuItemW(hMenu.value,
+                      UINT(index), true,
+                      &(child.info))
+    }
   }
 }


### PR DESCRIPTION
This change adds support for basic context menus (attached to a `View` instance) and window title menus. For both types of menus submenus are supported.