### PR TITLE
.gitignore: ignore more SPM artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@
 *~
 
 /build/
-.build/
 
-Package.resolved
+/package.resolved
+/Packages/
+.build/
 
 .vscode/


### PR DESCRIPTION
Ignore the `Packages/` directory and the `package.resolved` file from
SPM.