### PR TITLE
UI: wire up extension points for handling touch events

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(SwiftWin32 PRIVATE
   UI/DatePicker.swift
   UI/Device.swift
   UI/EdgeInsets.swift
+  UI/Event.swift
   UI/Font.swift
   UI/FontMetrics.swift
   UI/Label.swift
@@ -39,6 +40,7 @@ target_sources(SwiftWin32 PRIVATE
   UI/TextField.swift
   UI/TextInputTraits.swift
   UI/TextView.swift
+  UI/Touch.swift
   UI/TraitCollection.swift
   UI/TraitEnvironment.swift
   UI/View.swift

--- a/Sources/UI/Event.swift
+++ b/Sources/UI/Event.swift
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import struct Foundation.TimeInterval
+
+extension Event {
+  /// Specifies the general type of event.
+  public enum EventType: Int {
+  /// The event is related to touches on the screen.
+  case touches
+  /// The event is related to motion of the device.
+  case motion
+  /// The event is a remote-control event.
+  case remoteControl
+  /// The event is related to the press of a physical button.
+  case presses
+  }
+}
+
+extension Event {
+  /// Specifies the subtype of the event in relation to its general type.
+  public enum EventSubtype: Int {
+  /// The event has no subtype.
+  case none
+  /// The event is related to the user shaking the device.
+  case motionShake
+  /// A remote-control event for playing audio or video.
+  case remoteControlPlay
+  }
+}
+
+public class Event {
+  /// Getting Event Attributes
+
+  /// The time when the event occurred.
+  public var timestamp: TimeInterval
+
+  internal init(timestamp: TimeInterval) {
+    self.timestamp = timestamp
+  }
+}

--- a/Sources/UI/Responder.swift
+++ b/Sources/UI/Responder.swift
@@ -34,4 +34,26 @@ public class Responder {
   public func resignFirstResponder() -> Bool {
     return true
   }
+
+  /// Responding to Touch Events
+
+  /// Informs the responder that one or more new touches occurrd in a view or a
+  /// window.
+  public func touchesBegan(_ touches: Set<Touch>, with event: Event?) {
+  }
+
+  /// Informs the responder when one or more touches associated with an event
+  /// changed.
+  public func touchesMoved(_ touches: Set<Touch>, with event: Event?) {
+  }
+
+  /// Informs the responder when one or more fingers are raised from a view or a
+  /// window.
+  public func touchesEnded(_ touches: Set<Touch>, with event: Event?) {
+  }
+
+  /// Informs the responder when a system event (such as a system alert) cancels
+  /// a touch sequence.
+  public func touchesCancelled(_ touches: Set<Touch>, with event: Event?) {
+  }
 }

--- a/Sources/UI/Touch.swift
+++ b/Sources/UI/Touch.swift
@@ -1,0 +1,74 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import struct Foundation.TimeInterval
+
+extension Touch {
+  /// The type of touch received.
+  public enum TouchType: Int {
+  /// A touch resulting from direct contact with the screen.
+  case direct
+  /// A touch that did not result from direct contact with the screen.
+  case indirect
+  /// A touch from a stylus.
+  case pencil
+  }
+}
+
+extension Touch {
+  /// The phase of a touch event.
+  public enum Phase: Int {
+  /// A touch for a given event has pressed down on the screen.
+  case began
+  /// A touch for a given event has moved over the screen.
+  case moved
+  /// A touch for a given event is presseddown on the screen, but hasn't moved
+  /// since the previous event.
+  case stationary
+  /// A touch for a given event has lifted from the screen.
+  case ended
+  /// The system cancelled tracking for a touch, for example, when the user
+  /// moves the device against their face.
+  case cancelled
+  /// A touch for a given event has entered a window on the screen.
+  case regionEntered
+  /// A touch for the given event is within a window on the screen, but has not
+  /// yet pressed down.
+  case regionMoved
+  /// A touch for given event has left a window on the screen.
+  case regionExited
+  }
+}
+
+/// An object representing the location, size, movement, and force of a touch
+/// occurring on the screen.
+public class Touch {
+  /// Getting the Location of a Touch
+
+  /// The view to which touches are being delivered, if any.
+  public let view: View?
+
+  /// Getting Touch Attriutes
+
+  /// The time when the touch occurred or when it was last mutated.
+  public let timestamp: TimeInterval
+
+  internal init(for view: View?, at time: TimeInterval) {
+    self.view = view
+    self.timestamp = time
+  }
+}
+
+extension Touch: Hashable {
+  public static func ==(_ lhs: Touch, _ rhs: Touch) -> Bool {
+    return lhs.view == rhs.view && lhs.timestamp == rhs.timestamp
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    // TODO(compnerd) figure out how to hash a Touch
+  }
+}


### PR DESCRIPTION
Now that Windows will provide touch event information to the window via
the `WM_TOUCHINPUT` event, start adding the extension points for
handling the touch events.