### PR TITLE
UI: allow use of MS extension for anonymous structs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,10 +30,6 @@ let SwiftWin32 = Package(
         "CWinRT",
         "SwiftUIWin32",
       ],
-      cSettings: [
-        .define("COBJMACROS"),
-        .define("NONAMELESSUNION"),
-      ],
       swiftSettings: [
         .define("WITH_SWIFT_LOG"),
         .unsafeFlags(["-Xfrontend", "-validate-tbd-against-ir=none"]),

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -68,9 +68,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/WindowsHandle+UIExtensions.swift
   Support/WinSDK+Extensions.swift)
 target_compile_options(SwiftWin32 PRIVATE
-  "SHELL:-Xfrontend -validate-tbd-against-ir=none"
-  "SHELL:-Xcc -DNONAMELESSUNION"
-  "SHELL:-Xcc -DCOBJMACROS")
+  "SHELL:-Xfrontend -validate-tbd-against-ir=none")
 target_link_libraries(SwiftWin32 PUBLIC
   $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   ComCtl32

--- a/Sources/UI/Device.swift
+++ b/Sources/UI/Device.swift
@@ -107,18 +107,18 @@ public struct Device {
       return .unknown
     }
 
-    switch dmDeviceMode.u.s2.dmDisplayOrientation {
+    switch dmDeviceMode.dmDisplayOrientation {
     case DWORD(DMDO_90), DWORD(DMDO_270):
       swap(&dmDeviceMode.dmPelsHeight, &dmDeviceMode.dmPelsWidth)
     case DWORD(DMDO_DEFAULT), DWORD(DMDO_180):
       break
     default:
-      log.error("unknown display orientation: \(dmDeviceMode.u.s2.dmDisplayOrientation)")
+      log.error("unknown display orientation: \(dmDeviceMode.dmDisplayOrientation)")
       return .unknown
     }
 
     let bPortrait: Bool = dmDeviceMode.dmPelsWidth < dmDeviceMode.dmPelsHeight
-    switch dmDeviceMode.u.s2.dmDisplayOrientation {
+    switch dmDeviceMode.dmDisplayOrientation {
     case DWORD(DMDO_DEFAULT):
       return bPortrait ? .portrait : .landscapeLeft
     case DWORD(DMDO_90):


### PR DESCRIPTION
Now that the Swift compiler supports the MS anonymous structures
extension, use that in place of the workaround of naming the anonymous
fields.  This makes most instances of the code easier to read and
actually makes one of the type-casts explicit in the code.