### PR TITLE
build: remove workaround for older compiler releases

### DIFF
--- a/Examples/UICatalog/CMakeLists.txt
+++ b/Examples/UICatalog/CMakeLists.txt
@@ -9,5 +9,4 @@ add_custom_command(TARGET UICatalog POST_BUILD
 target_compile_options(UICatalog PRIVATE
   -parse-as-library)
 target_link_libraries(UICatalog PRIVATE
-  $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   SwiftWin32)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -70,7 +70,6 @@ target_sources(SwiftWin32 PRIVATE
 target_compile_options(SwiftWin32 PRIVATE
   "SHELL:-Xfrontend -validate-tbd-against-ir=none")
 target_link_libraries(SwiftWin32 PUBLIC
-  $<$<VERSION_LESS:${CMAKE_Swift_COMPILER_VERSION},5.3>:Gdi32>
   ComCtl32
   User32)
 target_link_libraries(SwiftWin32 PUBLIC


### PR DESCRIPTION
The project now requires a snapshot from 10/23 or newer.  Remove the
backwards compatibility support from the build.