### PR TITLE
UI: address TODO in `WindowSceneDelegate`

### DIFF
--- a/Sources/SwiftWin32/UI/WindowSceneDelegate.swift
+++ b/Sources/SwiftWin32/UI/WindowSceneDelegate.swift
@@ -8,19 +8,25 @@
 /// Additional methods that you can use to manage application specific tasks
 /// occurring in a scene.
 public protocol WindowSceneDelegate: SceneDelegate {
-  /// Managing the Scene's Main Window
+  // MARK - Managing the Scene's Main Window
 
-  // TODO(compnerd) make window optional
-  /// THe main window associated with the scene.
+  /// The main window associated with the scene.
   var window: Window? { get set }
 
-  /// Responding to Scene Changes
+  // MARK - Responding to Scene Changes
 
   /// Notifies you when the size, orientation, or traits of a scene change.
   func windowScene(_ windowScene: WindowScene,
                    didUpdate previousCoordinateSpace: CoordinateSpace,
                    interfaceOrientation previousInterfaceOrientation: InterfaceOrientation,
                    traitCollection previousTraitCollection: TraitCollection)
+}
+
+extension WindowSceneDelegate {
+  public var window: Window? {
+    get { return nil }
+    set { }
+  }
 }
 
 extension WindowSceneDelegate {


### PR DESCRIPTION
Make an optional property actually so, addressing the TODO in the
definition.  This cleans up the documentation while there.