### PR TITLE
UI: add `CoordinateSpace` protocol

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(SwiftWin32 PRIVATE
   UI/ContentContainer.swift
   UI/ContentsizeCategoryAdjusting.swift
   UI/Control.swift
+  UI/CoordinateSpace.swift
   UI/DatePicker.swift
   UI/Device.swift
   UI/EdgeInsets.swift


### PR DESCRIPTION
This protocol provides a set of methods for converting between different
frames of reference on a screen.