### PR TITLE
build: add Swift/COM module to the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
   OUTPUT_VARIABLE CASSOWARY_GIT_REVISION
   ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Packages/SwiftCOM"
+  OUTPUT_VARIABLE SWIFT_COM_GIT_REVISION
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 include(SwiftSupport)
 
@@ -39,5 +44,6 @@ add_subdirectory(Examples)
 
 message("-- Building with sub-modules:")
 message("--   Cassowary rG${CASSOWARY_GIT_REVISION}")
+message("--   Swift/COM rG${SWIFT_COM_GIT_REVISION}")
 export(TARGETS SwiftWin32
   FILE SwiftWin32Config.cmake)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -11,5 +11,44 @@ add_library(Cassowary SHARED
   ../Packages/cassowary/Sources/Cassowary/Variable.swift)
 swift_install(TARGETS Cassowary)
 
+add_library(SwiftCOM SHARED
+  ../Packages/SwiftCOM/Sources/SwiftCOM/COMBase.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Shell.swift)
+target_sources(SwiftCOM PRIVATE
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Extensions/COMTypes+Extensions.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Extensions/String+Extensions.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Extensions/WinSDK+Extensions.swift)
+target_sources(SwiftCOM PRIVATE
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Implementation/Human/IFileOperationProgressSink.swift)
+target_sources(SwiftCOM PRIVATE
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IMalloc.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IStream.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/ITypeComp.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/ITypeLib.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/IUnknown.swift)
+target_sources(SwiftCOM PRIVATE
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Support/Error.swift
+  ../Packages/SwiftCOM/Sources/SwiftCOM/Support/RawTyped.swift)
+target_link_libraries(SwiftCOM PUBLIC
+  Ole32)
+swift_install(TARGETS SwiftCOM)
+
 add_subdirectory(CWinRT)
 add_subdirectory(SwiftWin32)


### PR DESCRIPTION
Build SwiftCOM so that we can use that to initialize the COM threading
model within the application.