### PR TITLE
UI: add documentation comments and convert constants to vars

### DIFF
--- a/Sources/SwiftWin32/UI/Control.swift
+++ b/Sources/SwiftWin32/UI/Control.swift
@@ -40,12 +40,13 @@ private struct ControlEventCallback<Source: Control, Target: AnyObject>: Control
   }
 }
 
+/// The base class for controls, which are visual elements that convey a
+/// specific action or intention in response to user interactions.
 public class Control: View {
   private var actions: [Control.Event:[ControlEventCallable]] =
       Dictionary<Control.Event, [ControlEventCallable]>(minimumCapacity: 16)
 
-  /// Accessing the Control's Targets and Actions
-  public let allControlEvents: Control.Event = Control.Event(rawValue: 0)
+  // MARK - Accessing the Control's Targets and Actions
 
   @inline(__always)
   private func addAction(_ callable: ControlEventCallable,
@@ -57,6 +58,7 @@ public class Control: View {
     }
   }
 
+  /// Associates a target object and action method with the control.
   public func addTarget<Target: AnyObject>(_ target: Target,
                                            action: @escaping (Target) -> () -> Void,
                                            for controlEvents: Control.Event) {
@@ -64,6 +66,7 @@ public class Control: View {
                    for: controlEvents)
   }
 
+  /// Associates a target object and action method with the control.
   public func addTarget<Source: Control, Target: AnyObject>(_ target: Target,
                                                             action: @escaping (Target) -> (_: Source) -> Void,
                                                             for controlEvents: Control.Event) {
@@ -71,6 +74,11 @@ public class Control: View {
                    for: controlEvents)
   }
 
+  /// Returns the events for which the control has associated actions.
+  public private(set) var allControlEvents: Control.Event =
+      Control.Event(rawValue: 0)
+
+  /// Associates a target object and action method with the control.
   public func addTarget<Source: Control, Target: AnyObject>(_ target: Target,
                                                             action: @escaping (Target) -> (_: Source, _: Control.Event) -> Void,
                                                             for controlEvents: Control.Event) {
@@ -78,7 +86,9 @@ public class Control: View {
                    for: controlEvents)
   }
 
-  /// Triggering Actions
+  // MARK - Triggering Actions
+
+  /// Calls the action methods associated with the specified events.
   func sendActions(for controlEvents: Control.Event) {
     for event in Control.Event.touchEvents + Control.Event.semanticEvents + Control.Event.editingEvents {
       if controlEvents.rawValue & event.rawValue == event.rawValue {
@@ -89,6 +99,7 @@ public class Control: View {
 }
 
 public extension Control {
+  /// The state of the control, specified as a bit mask value.
   struct State: OptionSet {
     public let rawValue: Int
 
@@ -99,16 +110,45 @@ public extension Control {
 }
 
 public extension Control.State {
-  static let normal: Control.State = Control.State(rawValue: 1 << 0)
-  static let highlighted: Control.State = Control.State(rawValue: 1 << 1)
-  static let disabled: Control.State = Control.State(rawValue: 1 << 2)
-  static let selected: Control.State = Control.State(rawValue: 1 << 3)
-  static let focused: Control.State = Control.State(rawValue: 1 << 4)
-  static let application: Control.State = Control.State(rawValue: 1 << 5)
-  static let reserved: Control.State = Control.State(rawValue: 1 << 6)
+  /// The normal, or default state of a control—that is, enabled but neither
+  /// selected nor highlighted.
+  static var normal: Control.State {
+    Control.State(rawValue: 1 << 0)
+  }
+
+  /// Highlighted state of a control.
+  static var highlighted: Control.State {
+    Control.State(rawValue: 1 << 1)
+  }
+
+  /// Disabled state of a control.
+  static var disabled: Control.State {
+    Control.State(rawValue: 1 << 2)
+  }
+
+  /// Selected state of a control.
+  static var selected: Control.State {
+    Control.State(rawValue: 1 << 3)
+  }
+
+  /// Focused state of a control.
+  static var focused: Control.State {
+    Control.State(rawValue: 1 << 4)
+  }
+
+  /// Additional control-state flags available for application use.
+  static var application: Control.State {
+    Control.State(rawValue: 1 << 5)
+  }
+
+  /// Control-state flags reserved for internal framework use.
+  static var reserved: Control.State {
+    Control.State(rawValue: 1 << 6)
+  }
 }
 
 extension Control {
+  /// Constants describing the types of events possible for controls.
   public struct Event: Equatable, Hashable, RawRepresentable {
     public typealias RawValue = Int
 
@@ -121,53 +161,117 @@ extension Control {
 }
 
 extension Control.Event {
-  public static let touchDown: Control.Event =
-      Control.Event(rawValue: 1 << 0)
-  public static let touchDownRepeat: Control.Event =
-      Control.Event(rawValue: 1 << 1)
-  public static let touchDragInside: Control.Event =
-      Control.Event(rawValue: 1 << 2)
-  public static let touchDragOutside: Control.Event =
-      Control.Event(rawValue: 1 << 3)
-  public static let touchDragEnter: Control.Event =
-      Control.Event(rawValue: 1 << 4)
-  public static let touchDragExit: Control.Event =
-      Control.Event(rawValue: 1 << 5)
-  public static let touchUpInside: Control.Event =
-      Control.Event(rawValue: 1 << 6)
-  public static let touchUpOutside: Control.Event =
-      Control.Event(rawValue: 1 << 7)
-  public static let touchCancel: Control.Event =
-      Control.Event(rawValue: 1 << 8)
+  /// A touch-down event in the control.
+  public static var touchDown: Control.Event {
+    Control.Event(rawValue: 1 << 0)
+  }
 
-  public static let valueChanged: Control.Event =
-      Control.Event(rawValue: 1 << 12)
-  public static let menuActionTriggered: Control.Event =
-      Control.Event(rawValue: 0)
-  public static let primaryActionTriggered: Control.Event =
-      Control.Event(rawValue: 1 << 13)
+  /// A repeated touch-down event in the control; for this event the value of
+  /// the UITouch tapCount method is greater than one.
+  public static var touchDownRepeat: Control.Event {
+    Control.Event(rawValue: 1 << 1)
+  }
 
-  public static let editingDidBegin: Control.Event =
-      Control.Event(rawValue: 1 << 16)
-  public static let editingChanged: Control.Event =
-      Control.Event(rawValue: 1 << 17)
-  public static let editingDidEnd: Control.Event =
-      Control.Event(rawValue: 1 << 18)
-  public static let editingDidEndOnExit: Control.Event =
-      Control.Event(rawValue: 1 << 19)
+  /// An event where a finger is dragged inside the bounds of the control.
+  public static var touchDragInside: Control.Event {
+    Control.Event(rawValue: 1 << 2)
+  }
 
-  public static let allTouchEvents: Control.Event =
-      Control.Event(rawValue: 0x00000fff)
-  public static let allEditingEvents: Control.Event =
-      Control.Event(rawValue: 0x000f0000)
+  /// An event where a finger is dragged just outside the bounds of the control.
+  public static var touchDragOutside: Control.Event {
+    Control.Event(rawValue: 1 << 3)
+  }
 
-  public static let applicationReserved: Control.Event =
-      Control.Event(rawValue: 0x0f000000)
-  public static let systemReserved: Control.Event =
-      Control.Event(rawValue: 0xf0000000)
+  /// An event where a finger is dragged into the bounds of the control.
+  public static var touchDragEnter: Control.Event {
+    Control.Event(rawValue: 1 << 4)
+  }
 
-  public static let allEvents: Control.Event =
-      Control.Event(rawValue: 0xffffffff)
+  /// An event where a finger is dragged from within a control to outside its
+  /// bounds.
+  public static var touchDragExit: Control.Event {
+    Control.Event(rawValue: 1 << 5)
+  }
+
+  /// A touch-up event in the control where the finger is inside the bounds of
+  /// the control.
+  public static var touchUpInside: Control.Event {
+    Control.Event(rawValue: 1 << 6)
+  }
+
+  /// A touch-up event in the control where the finger is outside the bounds of
+  /// the control.
+  public static var touchUpOutside: Control.Event {
+    Control.Event(rawValue: 1 << 7)
+  }
+
+  /// A system event canceling the current touches for the control.
+  public static var touchCancel: Control.Event {
+    Control.Event(rawValue: 1 << 8)
+  }
+
+  /// A touch dragging or otherwise manipulating a control, causing it to emit
+  /// a series of different values.
+  public static var valueChanged: Control.Event {
+    Control.Event(rawValue: 1 << 12)
+  }
+
+  /// A menu action has triggered prior to the menu being presented.
+  public static var menuActionTriggered: Control.Event {
+    Control.Event(rawValue: 0)
+  }
+
+  /// A semantic action triggered by buttons.
+  public static var primaryActionTriggered: Control.Event {
+    Control.Event(rawValue: 1 << 13)
+  }
+
+  /// A touch initiating an editing session in a `TextField` object by entering
+  /// its bounds.
+  public static var editingDidBegin: Control.Event {
+    Control.Event(rawValue: 1 << 16)
+  }
+
+  /// A touch making an editing change in a `TextField` object.
+  public static var editingChanged: Control.Event {
+    Control.Event(rawValue: 1 << 17)
+  }
+
+  /// A touch ending an editing session in a `TextField` object by leaving its
+  /// bounds.
+  public static var editingDidEnd: Control.Event {
+    Control.Event(rawValue: 1 << 18)
+  }
+
+  /// A touch ending an editing session in a `TextField` object.
+  public static var editingDidEndOnExit: Control.Event {
+    Control.Event(rawValue: 1 << 19)
+  }
+
+  /// All touch events.
+  public static var allTouchEvents: Control.Event {
+    Control.Event(rawValue: 0x00000fff)
+  }
+
+  /// All editing touches for `TextField` objects.
+  public static var allEditingEvents: Control.Event {
+    Control.Event(rawValue: 0x000f0000)
+  }
+
+  /// A range of control-event values available for application use.
+  public static var applicationReserved: Control.Event {
+    Control.Event(rawValue: 0x0f000000)
+  }
+
+  /// A range of control-event values reserved for internal framework use.
+  public static var systemReserved: Control.Event {
+    Control.Event(rawValue: 0xf0000000)
+  }
+
+  /// All events, including system events.
+  public static var allEvents: Control.Event {
+    Control.Event(rawValue: 0xffffffff)
+  }
 }
 
 extension Control.Event {


### PR DESCRIPTION
Add some documentation comments to the `Control` interface.
Additionally, convert a number of constant values to `var` rather than
`let` constants to avoid storage.