### PR TITLE
Application: initialize COM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,5 +45,5 @@ add_subdirectory(Examples)
 message("-- Building with sub-modules:")
 message("--   Cassowary rG${CASSOWARY_GIT_REVISION}")
 message("--   Swift/COM rG${SWIFT_COM_GIT_REVISION}")
-export(TARGETS SwiftWin32
+export(TARGETS SwiftCOM SwiftWin32
   FILE SwiftWin32Config.cmake)

--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,16 @@ let SwiftWin32 = Package(
     // new CRT module.
     .package(url: "https://github.com/apple/swift-log.git", .branch("main")),
     .package(url: "https://github.com/compnerd/cassowary.git", .branch("master")),
+    .package(name: "SwiftCOM", url: "https://github.com/compnerd/swift-com.git",
+             .branch("master")),
   ],
   targets: [
     .target(
       name: "SwiftWin32",
       dependencies: [
         .product(name: "Logging", package: "swift-log"),
-        .product(name: "cassowary", package: "cassowary")
+        .product(name: "cassowary", package: "cassowary"),
+        .product(name: "SwiftCOM", package: "SwiftCOM"),
       ],
       path: "Sources/SwiftWin32",
       exclude: [

--- a/Sources/SwiftWin32/Application/ApplicationMain.swift
+++ b/Sources/SwiftWin32/Application/ApplicationMain.swift
@@ -6,6 +6,7 @@
  **/
 
 import WinSDK
+import SwiftCOM
 import Foundation
 
 private let pApplicationWindowProc: HOOKPROC = { (nCode: Int32, wParam: WPARAM, lParam: LPARAM) -> LRESULT in
@@ -99,6 +100,14 @@ public func ApplicationMain(_ argc: Int32,
             try? PropertyListDecoder().decode(Application.Information.self,
                                               from: contents)
       }
+  }
+
+  // Initialize COM
+  do {
+    try CoInitializeEx(COINIT_MULTITHREADED)
+  } catch {
+    log.error("CoInitializeEx: \(error)")
+    return EXIT_FAILURE
   }
 
   // Enable Per Monitor DPI Awareness

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -83,6 +83,8 @@ target_link_libraries(SwiftWin32 PUBLIC
   ComCtl32
   User32)
 target_link_libraries(SwiftWin32 PUBLIC
+  SwiftCOM)
+target_link_libraries(SwiftWin32 PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 if(WITH_SWIFT_LOG)


### PR DESCRIPTION
COM is intended to be used to access WIC (Windows Imaging Component) to
allow decoding (and potentially encoding) of images.  Use Swift/COM to
access nicer wrappers over the raw C interfaces for COM.