### PR TITLE
UI: prevent resizing of the window in fixed mode

### DIFF
--- a/Sources/SwiftWin32/UI/Window.swift
+++ b/Sources/SwiftWin32/UI/Window.swift
@@ -102,7 +102,7 @@ public class Window: View {
                           unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
     if let restrictions = windowScene.sizeRestrictions,
         restrictions.minimumSize == restrictions.maximumSize {
-      self.GWL_STYLE &= ~(WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
+      self.GWL_STYLE &= ~(WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SIZEBOX)
     }
 
     windowScene.windows.append(self)


### PR DESCRIPTION
If the scene restricts the window to the same minimum and maximum
dimensions, prevent the user from resizing the window bounds.  We would
previously remove the minimize and maximize buttons but would still
silently allow the user to resize the window bounds from the edge.
Unset the `WS_SIZEBOX` window style to prevent this.