### PR TITLE
UI: notify the scene delegate on window activation

### DIFF
--- a/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
@@ -31,8 +31,14 @@ public let MSFTEDIT_CLASS: String = "RICHEDIT50W"
 
 // winnt.h
 @_transparent
-public func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
+internal func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
   return DWORD((s << 10) | p)
+}
+
+// minwindef.h
+@_transparent
+internal func LOWORD<T: FixedWidthInteger>(_ dword: T) -> WORD {
+  return WORD(DWORD_PTR(dword) & 0xffff)
 }
 
 // WinUser.h

--- a/Sources/SwiftWin32/UI/SceneDelegate.swift
+++ b/Sources/SwiftWin32/UI/SceneDelegate.swift
@@ -8,7 +8,7 @@
 import WinSDK
 
 public protocol SceneDelegate: _TriviallyConstructible {
-  /// Connecting and Disconnecting the Scene
+  // MARK - Connecting and Disconnecting the Scene
 
   /// Tells the delegate about the addition of a scene to the application.
   func scene(_ scene: Scene, willConnectTo: SceneSession,
@@ -16,6 +16,26 @@ public protocol SceneDelegate: _TriviallyConstructible {
 
   /// Tells the delegate that a scene was removed from the application.
   func sceneDidDisconnect(_ scene: Scene)
+
+  // MARK - Transitioning to the Foreground
+
+  /// Tells the delegate that the scene is about to begin running in the
+  /// foreground and become visible to the user.
+  func sceneWillEnterForeground(_ scene: Scene)
+
+  /// Tells the delegate that the scene became active and is now responding to
+  /// user events.
+  func sceneDidBecomeActive(_ scene: Scene)
+
+  // MARK - Transitioning to the Background
+
+  /// Tells the delegate that the scene is about to resign the active state and
+  /// stop responding to user events.
+  func sceneWillResignActive(_ scene: Scene)
+
+  /// Tells the delegate that the scene is running in the background and is no
+  /// longer onscreen.
+  func sceneDidEnterBackground(_ scene: Scene)
 }
 
 extension SceneDelegate {
@@ -24,5 +44,21 @@ extension SceneDelegate {
   }
 
   public func sceneDidDisconnect(_ scene: Scene) {
+  }
+}
+
+extension SceneDelegate {
+  public func sceneWillEnterForeground(_ scene: Scene) {
+  }
+
+  public func sceneDidBecomeActive(_ scene: Scene) {
+  }
+}
+
+extension SceneDelegate {
+  public func sceneWillResignActive(_ scene: Scene) {
+  }
+
+  public func sceneDidEnterBackground(_ scene: Scene) {
   }
 }

--- a/Sources/SwiftWin32/UI/Window.swift
+++ b/Sources/SwiftWin32/UI/Window.swift
@@ -63,6 +63,16 @@ private let SwiftWindowProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSu
         POINT(from: ClientSizeToWindowSize(restrictions.maximumSize))
 
     return LRESULT(0)
+  case UINT(WM_ACTIVATE):
+    guard let window = window, let windowScene = window.windowScene else { break }
+    switch LOWORD(wParam) {
+    case WORD(WA_ACTIVE), WORD(WA_CLICKACTIVE):
+      windowScene.delegate?.sceneDidBecomeActive(windowScene)
+    case WORD(WA_INACTIVE):
+      windowScene.delegate?.sceneDidEnterBackground(windowScene)
+    default:
+      fatalError("WM_ACTIVATE wParam: 0x\(String(wParam, radix: 16)), lParam: 0x\(String(lParam, radix: 16))")
+    }
   default:
     break
   }


### PR DESCRIPTION
Wire up `WM_ACTIVATE` to trigger the delegate updates for window
resigning foreground and becoming active.