### PR TITLE
docs: homogenise documentation style (NFC)

### DIFF
--- a/Sources/SwiftWin32/Application/ApplicationDelegate.swift
+++ b/Sources/SwiftWin32/Application/ApplicationDelegate.swift
@@ -43,12 +43,12 @@ extension InterfaceOrientation {
 public protocol ApplicationDelegate: class, _TriviallyConstructible {
   // MARK - Initializing the App
 
-  /// Indicates to the delegate that the application launch process has begun.
+  /// Informs the delegate that the application launch process has begun.
   func application(_ application: Application,
                    willFinishLaunchingWithOptions options: [Application.LaunchOptionsKey:Any]?)
       -> Bool
 
-  /// Indicates to the delegate that the application launch process has ended and
+  /// Informs the delegate that the application launch process has ended and
   /// the application is almost ready to run.
   func application(_ application: Application,
                    didFinishLaunchingWithOptions options: [Application.LaunchOptionsKey:Any]?)
@@ -56,19 +56,19 @@ public protocol ApplicationDelegate: class, _TriviallyConstructible {
 
   // MARK - Responding to App Life-Cycle Events
 
-  /// Indicates to the delegate that the application has become active.
+  /// Informs the delegate that the application has become active.
   func applicationDidBecomeActive(_ application: Application)
 
-  /// Indicates to the delgate that the application is about to become inactive.
+  /// Informs the delgate that the application is about to become inactive.
   func applicationWillResignActive(_ application: Application)
 
-  /// Indicates to the delegate that the application is now in the background.
+  /// Informs the delegate that the application is now in the background.
   func applicationDidEnterBackground(_ application: Application)
 
-  /// Indicates to the delegate that the application is about to enter the foreground.
+  /// Informs the delegate that the application is about to enter the foreground.
   func applicationWillEnterForeground(_ application: Application)
 
-  /// Indicates to the delegate that the application is about to terminate.
+  /// Informs the delegate that the application is about to terminate.
   func applicationWillTerminate(_ application: Application)
 
   /// Responding to Environment Changes
@@ -84,7 +84,7 @@ public protocol ApplicationDelegate: class, _TriviallyConstructible {
                    configurationForConnecting connectingSceneSession: SceneSession,
                    options: Scene.ConnectionOptions) -> SceneConfiguration
 
-  /// Tells the delegate that the user closed one or more of teh application's
+  /// Informs the delegate that the user closed one or more of the application's
   /// scenes.
   func application(_ application: Application,
                    didDiscardSceneSessions sceneSessions: Set<SceneSession>)

--- a/Sources/SwiftWin32/UI/SceneDelegate.swift
+++ b/Sources/SwiftWin32/UI/SceneDelegate.swift
@@ -10,30 +10,30 @@ import WinSDK
 public protocol SceneDelegate: _TriviallyConstructible {
   // MARK - Connecting and Disconnecting the Scene
 
-  /// Tells the delegate about the addition of a scene to the application.
+  /// Informs the delegate about the addition of a scene to the application.
   func scene(_ scene: Scene, willConnectTo: SceneSession,
              options: Scene.ConnectionOptions)
 
-  /// Tells the delegate that a scene was removed from the application.
+  /// Informs the delegate that a scene was removed from the application.
   func sceneDidDisconnect(_ scene: Scene)
 
   // MARK - Transitioning to the Foreground
 
-  /// Tells the delegate that the scene is about to begin running in the
+  /// Informs the delegate that the scene is about to begin running in the
   /// foreground and become visible to the user.
   func sceneWillEnterForeground(_ scene: Scene)
 
-  /// Tells the delegate that the scene became active and is now responding to
+  /// Informs the delegate that the scene became active and is now responding to
   /// user events.
   func sceneDidBecomeActive(_ scene: Scene)
 
   // MARK - Transitioning to the Background
 
-  /// Tells the delegate that the scene is about to resign the active state and
-  /// stop responding to user events.
+  /// Informs the delegate that the scene is about to resign the active state
+  /// and stop responding to user events.
   func sceneWillResignActive(_ scene: Scene)
 
-  /// Tells the delegate that the scene is running in the background and is no
+  /// Informs the delegate that the scene is running in the background and is no
   /// longer onscreen.
   func sceneDidEnterBackground(_ scene: Scene)
 }

--- a/Sources/SwiftWin32/UI/TableViewDataSource.swift
+++ b/Sources/SwiftWin32/UI/TableViewDataSource.swift
@@ -10,7 +10,7 @@ import struct Foundation.IndexPath
 public protocol TableViewDataSource: class {
   /// Providng the Number of Rows and Sections
 
-  /// Tells the data source to return the number of rows in a given section of
+  /// Informs the data source to return the number of rows in a given section of
   /// a table view.
   func tableView(_ tableView: TableView, numberOfRowsInSection section: Int)
       -> Int

--- a/Sources/SwiftWin32/UI/View.swift
+++ b/Sources/SwiftWin32/UI/View.swift
@@ -349,20 +349,20 @@ public class View: Responder {
 
   // MARK - Observing View-Related Changes
 
-  /// Tells the view that a subview was added.
+  /// Informs the view that a subview was added.
   public func didAddSubview(_ subview: View) {
   }
 
-  /// Tells the view that a subview is about to be removed.
+  /// Informs the view that a subview is about to be removed.
   public func willRemoveSubview(_ subview: View) {
   }
 
-  /// Tells the view that its superview is about to change to the specified
+  /// Informs the view that its superview is about to change to the specified
   /// superview.
   public func willMove(toSuperview: View?) {
   }
 
-  /// Tells the view that its superview changed.
+  /// Informs the view that its superview changed.
   public func didMoveToSuperview() {
   }
 


### PR DESCRIPTION
Use similar language throughout the project's doc comments relating to
informing the delegate.