### PR TITLE
Application: remove unnecessary qualifier

### DIFF
--- a/Sources/SwiftWin32/Application/Application.swift
+++ b/Sources/SwiftWin32/Application/Application.swift
@@ -26,7 +26,7 @@ public class Application: Responder {
 
   /// A boolean indicating whether the application may display multiple scenes.
   public var supportsMultipleScenes: Bool {
-    Application.shared.information?.scene?.supportsMultipleScenes ?? false
+    information?.scene?.supportsMultipleScenes ?? false
   }
 
   /// The application's currently connected scenes.


### PR DESCRIPTION
Since `supportsMultipleScenes` is non-static, there's no need to access through the `shared` instance.