### PR TITLE
Support: hoist GUID equality into the Support layer

### DIFF
--- a/Sources/SwiftWin32/Platform/BatteryMonitor.swift
+++ b/Sources/SwiftWin32/Platform/BatteryMonitor.swift
@@ -8,25 +8,6 @@
 import WinSDK
 import class Foundation.NotificationCenter
 
-private func ==<T: Equatable>(_ lhs: (T, T, T, T, T, T, T, T),
-                              _ rhs: (T, T, T, T, T, T, T, T)) -> Bool {
-  return lhs.0 == rhs.0 &&
-         lhs.1 == rhs.1 &&
-         lhs.2 == rhs.2 &&
-         lhs.3 == rhs.3 &&
-         lhs.4 == rhs.4 &&
-         lhs.5 == rhs.5 &&
-         lhs.6 == rhs.6 &&
-         lhs.7 == rhs.7
-}
-
-private func ~=(_ lhs: GUID, _ rhs: GUID) -> Bool {
-  return lhs.Data1 == rhs.Data1 &&
-         lhs.Data2 == rhs.Data2 &&
-         lhs.Data3 == rhs.Data3 &&
-         lhs.Data4 == rhs.Data4
-}
-
 private let SwiftBatteryMonitorProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let monitor: BatteryMonitor? =
       unsafeBitCast(dwRefData, to: AnyObject.self) as? BatteryMonitor

--- a/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
@@ -81,3 +81,22 @@ func EnableMenuItem(_ hMenu: HMENU, _ uIDEnableItem: UINT, _ uEnable: UINT)
                     to: ((HMENU?, UINT, UINT) -> CInt).self)
   return pfnEnableMenuItem(hMenu, uIDEnableItem, uEnable)
 }
+
+private func ==<T: Equatable>(_ lhs: (T, T, T, T, T, T, T, T),
+                              _ rhs: (T, T, T, T, T, T, T, T)) -> Bool {
+  return lhs.0 == rhs.0 &&
+         lhs.1 == rhs.1 &&
+         lhs.2 == rhs.2 &&
+         lhs.3 == rhs.3 &&
+         lhs.4 == rhs.4 &&
+         lhs.5 == rhs.5 &&
+         lhs.6 == rhs.6 &&
+         lhs.7 == rhs.7
+}
+
+internal func ~=(_ lhs: GUID, _ rhs: GUID) -> Bool {
+  return lhs.Data1 == rhs.Data1 &&
+         lhs.Data2 == rhs.Data2 &&
+         lhs.Data3 == rhs.Data3 &&
+         lhs.Data4 == rhs.Data4
+}


### PR DESCRIPTION
The ability to check for `GUID` equality is rather common on Windows.
Move the internal implementation from the `BatteryMonitor` into the
WinSDK extensions and make it available internally to the module.