### PR TITLE
build: fix SwiftPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,10 @@ let SwiftWin32 = Package(
       dependencies: [
         "SwiftWin32",
       ],
-      path: "Sources/SwiftWin32UI"
+      path: "Sources/SwiftWin32UI",
+      exclude: [
+        "CMakeLists.txt",
+      ]
     ),
     .target(
       name: "Calculator",


### PR DESCRIPTION
SwiftPM prints this warning when trying to build the package:

```
'SwiftWin32' C:\Users\Egor Zhdan\swift-win32: warning: found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    C:\Users\Egor Zhdan\swift-win32\Sources\SwiftWin32UI\CMakeLists.txt
```