### PR TITLE
UI: add containing `View` for each `Label`

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Label.swift
+++ b/Sources/SwiftWin32/Views and Controls/Label.swift
@@ -21,21 +21,61 @@ private let SwiftLabelProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSub
 }
 
 public class Label: Control {
-  private static let `class`: WindowClass = WindowClass(named: WC_STATIC)
-  private static let style: WindowStyle = (base: WS_TABSTOP | DWORD(SS_NOTIFY), extended: 0)
+  private static let `class`: WindowClass =
+      WindowClass(hInst: GetModuleHandleW(nil), name: "Swift.Label")
+  private static let style: WindowStyle = (base: WS_TABSTOP, extended: 0)
 
-  public override var font: Font! {
-    get { return super.font }
-    set(value) { super.font = value }
+  private var staticHWnd: HWND!
+
+  public var text: String? {
+    get {
+      let szLength: Int32 = GetWindowTextLengthW(self.staticHWnd)
+      let buffer: [WCHAR] = Array<WCHAR>(unsafeUninitializedCapacity: Int(szLength) + 1) {
+        $1 = Int(GetWindowTextW(self.staticHWnd, $0.baseAddress!, CInt($0.count)))
+      }
+      return String(decodingCString: buffer, as: UTF16.self)
+    }
+    set(value) { _ = SetWindowTextW(self.staticHWnd, value?.wide) }
   }
 
-  @_Win32WindowText
-  public var text: String?
+  public override var font: Font! {
+    didSet {
+      SendMessageW(self.staticHWnd, UINT(WM_SETFONT),
+                   unsafeBitCast(self.font?.hFont.value, to: WPARAM.self),
+                   LPARAM(1))
+    }
+  }
+
+  public override var frame: Rect {
+    didSet {
+      let rect = GetRect(hWnd: self.hWnd)
+      _ = SetWindowPos(self.staticHWnd, nil,
+                       CInt(rect.origin.x), CInt(rect.origin.y),
+                       CInt(rect.size.width), CInt(rect.size.height),
+                       UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
+    }
+  }
 
   public init(frame: Rect) {
     super.init(frame: frame, class: Label.class, style: Label.style)
     _ = SetWindowSubclass(hWnd, SwiftLabelProc, UINT_PTR(1),
                          unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
+
+    let rect = GetRect(hWnd: self.hWnd)
+    self.staticHWnd = CreateWindowExW(0, WC_STATIC.wide, nil, 0,
+                                      0, 0,
+                                      Int32(rect.size.width),
+                                      Int32(rect.size.height),
+                                      nil, nil, GetModuleHandleW(nil), nil)!
+
+    _ = SetWindowLongW(self.staticHWnd, WinSDK.GWL_STYLE, WS_CHILD)
+    _ = SetParent(self.staticHWnd, self.hWnd)
+
+    self.font = Font.systemFont(ofSize: Font.systemFontSize)
+  }
+
+  deinit {
+    DestroyWindow(self.staticHWnd)
   }
 
   // ContentSizeCategoryAdjusting

--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -76,6 +76,19 @@ private func ScaleClient(rect: inout Rect, for dpi: UINT, _ style: WindowStyle) 
   rect = Rect(from: r)
 }
 
+internal func GetRect(hWnd: HWND) -> Rect {
+  var r: RECT = RECT()
+  if !GetClientRect(hWnd, &r) {
+    log.warning("GetClientRect: \(Error(win32: GetLastError()))")
+  }
+  _ = withUnsafeMutablePointer(to: &r) { [hWnd] in
+    $0.withMemoryRebound(to: POINT.self, capacity: 2) {
+      MapWindowPoints(hWnd, nil, $0, 2)
+    }
+  }
+  return Rect(from: r)
+}
+
 extension View {
   /// Options to specify how a view adjusts its content when its size changes.
   public enum ContentMode: Int {
@@ -241,16 +254,7 @@ public class View: Responder {
     // If `CW_USEDEFAULT` was used, query the actual allocated rect
     if frame.origin.x == Double(CW_USEDEFAULT) ||
        frame.size.width == Double(CW_USEDEFAULT) {
-      var r: RECT = RECT()
-      if !GetClientRect(self.hWnd, &r) {
-        log.warning("GetClientRect: \(Error(win32: GetLastError()))")
-      }
-      _ = withUnsafeMutablePointer(to: &r) { [hWnd = self.hWnd] in
-        $0.withMemoryRebound(to: POINT.self, capacity: 2) {
-          MapWindowPoints(hWnd, nil, $0, 2)
-        }
-      }
-      client = Rect(from: r)
+      client = GetRect(hWnd: self.hWnd)
     }
 
     // Scale window for DPI


### PR DESCRIPTION
`WC_STATIC` control doesn't receive events like `WM_CONTEXTMENU`. To be able to handle those events, let's create containing views for `WC_STATIC` instances.