### PR TITLE
SwiftWin32: conform protocols to `AnyObject`

### DIFF
--- a/Sources/SwiftWin32/Application/ApplicationDelegate.swift
+++ b/Sources/SwiftWin32/Application/ApplicationDelegate.swift
@@ -40,7 +40,7 @@ extension InterfaceOrientation {
 }
 
 /// A set of methods used to manage shared behaviours for the application.
-public protocol ApplicationDelegate: class, _TriviallyConstructible {
+public protocol ApplicationDelegate: AnyObject, _TriviallyConstructible {
   // MARK - Initializing the App
 
   /// Informs the delegate that the application launch process has begun.

--- a/Sources/SwiftWin32/UI/TableViewDataSource.swift
+++ b/Sources/SwiftWin32/UI/TableViewDataSource.swift
@@ -7,7 +7,7 @@
 
 import struct Foundation.IndexPath
 
-public protocol TableViewDataSource: class {
+public protocol TableViewDataSource: AnyObject {
   /// Providng the Number of Rows and Sections
 
   /// Informs the data source to return the number of rows in a given section of

--- a/Sources/SwiftWin32/UI/TextField.swift
+++ b/Sources/SwiftWin32/UI/TextField.swift
@@ -7,7 +7,7 @@
 
 import WinSDK
 
-public protocol TextFieldDelegate: class {
+public protocol TextFieldDelegate: AnyObject {
 }
 
 private let SwiftTextFieldProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in


### PR DESCRIPTION
Address the recent warning that was added for deriving protocols from
`class`.