### PR TITLE
SwiftWin32: add Size,Point,Rect convenience initializers

### DIFF
--- a/Sources/SwiftWin32/CG/Rect.swift
+++ b/Sources/SwiftWin32/CG/Rect.swift
@@ -22,7 +22,7 @@ public struct Rect {
   }
 
   public init(x: Int, y: Int, width: Int, height: Int) {
-    self.init(origin: Point(x: Double(x), y: Double(y)),
+    self.init(origin: Point(x: x, y: y),
               size: Size(width: Double(width), height: Double(height)))
   }
 

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(SwiftWin32 PRIVATE
   Support/Logging.swift
   Support/Rect+UIExtensions.swift
   Support/Point+UIExtensions.swift
+  Support/Size+UIExtensions.swift
   Support/String+UIExtensions.swift
   Support/WindowsHandle+UIExtensions.swift
   Support/WinSDK+Extensions.swift)

--- a/Sources/SwiftWin32/Support/Point+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/Point+UIExtensions.swift
@@ -30,3 +30,9 @@ extension POINT {
     self.init(x: LONG(from.width), y: LONG(from.height))
   }
 }
+
+extension Point {
+  internal init<Integer: FixedWidthInteger>(x: Integer, y: Integer) {
+    self.init(x: Int(x), y: Int(y))
+  }
+}

--- a/Sources/SwiftWin32/Support/Rect+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/Rect+UIExtensions.swift
@@ -9,17 +9,17 @@ import WinSDK
 
 extension Rect {
   internal init(from: RECT) {
-    self.origin = Point(x: Double(from.left), y: Double(from.top))
-    self.size = Size(width: Double(from.right - from.left),
-                     height: Double(from.bottom - from.top))
+    self.origin = Point(x: from.left, y: from.top)
+    self.size = Size(width: from.right - from.left,
+                     height: from.bottom - from.top)
   }
 }
 
 extension RECT {
   internal init(from: Rect) {
-    self.init(left: Int32(from.origin.x),
-              top: Int32(from.origin.y),
-              right: Int32(from.origin.x + from.size.width),
-              bottom: Int32(from.origin.y + from.size.height))
+    self.init(left: LONG(from.origin.x),
+              top: LONG(from.origin.y),
+              right: LONG(from.origin.x + from.size.width),
+              bottom: LONG(from.origin.y + from.size.height))
   }
 }

--- a/Sources/SwiftWin32/Support/Size+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/Size+UIExtensions.swift
@@ -1,0 +1,12 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+extension Size {
+  internal init<Integer: FixedWidthInteger>(width: Integer, height: Integer) {
+    self.init(width: Int(width), height: Int(height))
+  }
+}


### PR DESCRIPTION
It is very common to construct these types from various fixed-width
values.  Provide a generalized constructor to convert any fixed-width
integer type to the proper type.