### PR TITLE
UI: refactor, simplify menu handling

### DIFF
--- a/Sources/SwiftWin32/UI/Menu.swift
+++ b/Sources/SwiftWin32/UI/Menu.swift
@@ -255,7 +255,7 @@ extension Menu.Identifier {
 
 
 extension Menu {
-  /// Options for configuring a menu's appearance.
+  // MARK - Options for configuring a menu's appearance.
   public struct Options: OptionSet {
     public typealias RawValue = UInt
 
@@ -284,7 +284,7 @@ extension Menu.Options {
 /// A container for grouping related menu elements in an application menu or
 /// contextual menu.
 public class Menu: MenuElement {
-  /// Creating a Menu Object
+  // MARK - Creating a Menu Object
 
   /// Creates a new menu with the specified values.
   public init(title: String = "", image: Image? = nil,
@@ -318,15 +318,14 @@ public class Menu: MenuElement {
 
 internal struct Win32Menu {
   internal let hMenu: MenuHandle
-  private let children: [Win32MenuElement]
 
-  internal init(_ hMenu: MenuHandle, children: [MenuElement]) {
+  private let items: [Win32MenuElement]
+
+  internal init(_ hMenu: MenuHandle, items: [MenuElement]) {
     self.hMenu = hMenu
-    self.children = children.map { Win32MenuElement.of($0) }
-    for (index, child) in self.children.enumerated() {
-      InsertMenuItemW(hMenu.value,
-                      UINT(index), true,
-                      &(child.info))
+    self.items = items.map { Win32MenuElement($0) }
+    for (index, child) in self.items.enumerated() {
+      InsertMenuItemW(hMenu.value, UINT(index), true, &child.info)
     }
   }
 }


### PR DESCRIPTION
Split out the separator handling for `Win32MenuElement` into an
extension, reducing the amount of content in the main definition.

Replace the `of` "constructor" to a `convenience init` on
`Win32MenuElement`.

Rename the `win32ContextMenu` to `menu` in `View`.

Ad a generic helper to identify and cast the interaction from the view's
interactions.

Simplify the `WM_CONTEXTMENU` routine by always clearing the `menu`
field, replacing the menu, avoiding two separate paths.  Collapse the
access of the actions from the context menu configuration provided by
the delegate into a single chained query.  If one is provided, then only
do we create a new menu.