### PR TITLE
SwiftWin32: replace inheritance from `class` with `AnyObject`

### DIFF
--- a/Sources/SwiftWin32/UI/ContextMenuInteractionDelegate.swift
+++ b/Sources/SwiftWin32/UI/ContextMenuInteractionDelegate.swift
@@ -7,7 +7,7 @@
 
 /// The methods for providing the set of actions to perform on your content,
 /// and for customizing the preview of that content.
-public protocol ContextMenuInteractionDelegate: class {
+public protocol ContextMenuInteractionDelegate: AnyObject {
   // MARK - Providing the Preview Configuration Data
 
   /// Returns the configuration data to use when previewing the content.

--- a/Sources/SwiftWin32/UI/Interaction.swift
+++ b/Sources/SwiftWin32/UI/Interaction.swift
@@ -6,7 +6,7 @@
  **/
 
 /// The protocol that an interaction implements to access the view that owns it.
-public protocol Interaction: class {
+public protocol Interaction: AnyObject {
   // MARK - Getting the View
 
   /// The view that owns the interaction.


### PR DESCRIPTION
This resolves the deprecation warnings for class constrained protocols,
by replacing the `class` inheritance with `AnyObject`.