### PR TITLE
Tests: add an initial test harness setup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -103,5 +103,9 @@ let SwiftWin32 = Package(
         ]),
       ]
     ),
+    .testTarget(
+      name: "AutoLayoutTests",
+      dependencies: ["SwiftWin32"]
+    ),
   ]
 )

--- a/Tests/AutoLayoutTests/AutoLayoutTests.swift
+++ b/Tests/AutoLayoutTests/AutoLayoutTests.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import XCTest
+
+import SwiftWin32
+
+final class AutoLayoutTests: XCTestCase {
+  func testLayoutConstraintInactiveByDefault() {
+    XCTAssertFalse(LayoutConstraint(item: self, attribute: .left,
+                                    relatedBy: .equal,
+                                    toItem: nil, attribute: .notAnAttribute,
+                                    multiplier: 1.0, constant: 0.0).isActive)
+  }
+
+  static var allTests = [
+    ("testLayoutConstraintInactiveByDefault", testLayoutConstraintInactiveByDefault),
+  ]
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,15 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import XCTest
+
+@testable
+import AutoLayoutTests
+
+XCTMain([
+  testCase(AutoLayoutTests.allTests),
+])


### PR DESCRIPTION
Add some test harness for enabling testing `LayoutConstraint`.  The
layout constraint paths are not rendering related and can be tested more
readily.