### PR TITLE
UI: adjust client area during reparenting

### DIFF
--- a/Sources/SwiftWin32/UI/TableView.swift
+++ b/Sources/SwiftWin32/UI/TableView.swift
@@ -48,8 +48,12 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
 
     if let view = unsafeBitCast(lpMeasurement.pointee.itemData,
                                 to: AnyObject.self) as? View {
-      lpMeasurement.pointee.itemHeight = UINT(view.frame.size.height)
-      lpMeasurement.pointee.itemWidth = UINT(view.frame.size.width)
+      var r: RECT = RECT()
+      _ = GetClientRect(view.hWnd, &r)
+      var client: Rect = Rect(from: r)
+
+      lpMeasurement.pointee.itemHeight = UINT(client.size.height)
+      lpMeasurement.pointee.itemWidth = UINT(client.size.width)
     }
 
     return LRESULT(1)

--- a/Sources/SwiftWin32/UI/TextField.swift
+++ b/Sources/SwiftWin32/UI/TextField.swift
@@ -33,11 +33,7 @@ private let SwiftTextFieldProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uI
 
     // Get the Client Rect
     var rctClient: RECT = RECT()
-    _ = withUnsafeMutablePointer(to: &rctClient) {
-      SendMessageW(hWnd, UINT(EM_GETRECT), 0,
-                   LPARAM(bitPattern: UInt64(Int(bitPattern: $0))))
-    }
-
+    _ = GetClientRect(hWnd, &rctClient)
     _ = SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT))
     _ = SetBkMode(hDC, TRANSPARENT)
     _ = DrawTextW(hDC, placeholder.LPCWSTR, -1, &rctClient,

--- a/Sources/SwiftWin32/UI/View.swift
+++ b/Sources/SwiftWin32/UI/View.swift
@@ -287,10 +287,18 @@ public class View: Responder {
       log.warning("SetWindowPos: \(Error(win32: GetLastError()))")
     }
 
-    // TODO(compnerd) check for error
+    // Scale window for DPI
+    let style: WindowStyle =
+        WindowStyle(DWORD(bitPattern: view.GWL_STYLE),
+                    DWORD(bitPattern: view.GWL_EXSTYLE))
+
+    var client: Rect = view.frame
+    ScaleClient(rect: &client, for: GetDpiForWindow(view.hWnd), style)
+
+    // Resize and Position the Window
     _ = SetWindowPos(view.hWnd, nil,
-                     CInt(view.frame.origin.x), CInt(view.frame.origin.y),
-                     CInt(view.frame.size.width), CInt(view.frame.size.height),
+                     CInt(client.origin.x), CInt(client.origin.y),
+                     CInt(client.size.width), CInt(client.size.height),
                      UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
 
     view.superview = self


### PR DESCRIPTION
When the view is reparented, we cannot simply query the frame and use
the value.  We must scale the value appropriately for the current DPI
scaling.  This is required since we store the requested scale rather
than the rendered scale (which allows greater flexibility).

Fixes: #315