### PR TITLE
build,UICatalog: correct the bundle layout

### DIFF
--- a/Examples/UICatalog/CMakeLists.txt
+++ b/Examples/UICatalog/CMakeLists.txt
@@ -4,7 +4,9 @@ add_custom_command(TARGET UICatalog POST_BUILD
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/UICatalog.exe.manifest $<TARGET_FILE_DIR:UICatalog>
   COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist $<TARGET_FILE_DIR:UICatalog>)
+    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist $<TARGET_FILE_DIR:UICatalog>
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Assets/CoffeeCup.jpg $<TARGET_FILE_DIR:UICatalog>)
 # FIXME(SR-12683) `@main` requires `-parse-as-library`
 target_compile_options(UICatalog PRIVATE
   -parse-as-library)

--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -70,13 +70,15 @@ final class UICatalog: ApplicationDelegate, SceneDelegate {
 
   lazy var imageview: ImageView = {
 #if SWIFT_PACKAGE
-    let bundle = Bundle.module
+    let bundle: Bundle = Bundle.module
 #else
-    let bundle = Bundle.main
+    let bundle: Bundle = Bundle.main
 #endif
-    let image: Image? =
-        Image(contentsOfFile: bundle.url(forResource: "CoffeeCup",
-                                         withExtension: "jpg")!.path)
+    guard let resource: URL =
+        bundle.url(forResource: "CoffeeCup", withExtension: "jpg") else {
+      fatalError("Unable to load resource `CoffeeCup.jpg`")
+    }
+    let image: Image? = Image(contentsOfFile: resource.path)
     let view = ImageView(image: image)
     view.frame = Rect(x: 64.0, y: 368.0, width: 128.0, height: 128.0)
     return view


### PR DESCRIPTION
Ensure that we copy the resource into the main bundle (output
directory).  Make the failure to load the resource more explicit as it
was confusing to others.

Fixes: #330