### PR TITLE
UI: shuffle groups around in `View` (NFC)

### DIFF
--- a/Sources/SwiftWin32/UI/View.swift
+++ b/Sources/SwiftWin32/UI/View.swift
@@ -107,6 +107,22 @@ public class View: Responder {
 
   internal var menu: Win32Menu? = nil
 
+  // MARK - Configuring a View's Visual Appearance
+
+  /// A boolean that determines if the view is hidden.
+  public var isHidden: Bool {
+    get { IsWindowVisible(self.hWnd) }
+    set(hidden) {
+      let pEnumFunc: WNDENUMPROC = { (hWnd, lParam) -> WindowsBool in
+        ShowWindow(hWnd, CInt(lParam))
+        return true
+      }
+      _ = EnumChildWindows(self.hWnd, pEnumFunc,
+                           LPARAM(hidden ? SW_HIDE : SW_RESTORE))
+      ShowWindow(self.hWnd, hidden ? SW_HIDE : SW_RESTORE)
+    }
+  }
+
   // MARK - Creating a View Object
 
   // FIXME(compnerd) should this be marked as a convenience initializer?
@@ -184,22 +200,6 @@ public class View: Responder {
     _ = UnregisterTouchWindow(self.hWnd)
     _ = DestroyWindow(self.hWnd)
     _ = self.WndClass.unregister()
-  }
-
-  // MARK - Configuring a View's Visual Appearance
-
-  /// A boolean that determines if the view is hidden.
-  public var isHidden: Bool {
-    get { IsWindowVisible(self.hWnd) }
-    set(hidden) {
-      let pEnumFunc: WNDENUMPROC = { (hWnd, lParam) -> WindowsBool in
-        ShowWindow(hWnd, CInt(lParam))
-        return true
-      }
-      _ = EnumChildWindows(self.hWnd, pEnumFunc,
-                           LPARAM(hidden ? SW_HIDE : SW_RESTORE))
-      ShowWindow(self.hWnd, hidden ? SW_HIDE : SW_RESTORE)
-    }
   }
 
   // MARK - Configuring the Event-Related Behaviour


### PR DESCRIPTION
Reorder a couple of the groups around for `View`.