### PR TITLE
UI: scale the font for the TextField placeholder

### DIFF
--- a/Sources/SwiftWin32/UI/TextField.swift
+++ b/Sources/SwiftWin32/UI/TextField.swift
@@ -34,10 +34,16 @@ private let SwiftTextFieldProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uI
     // Get the Client Rect
     var rctClient: RECT = RECT()
     _ = GetClientRect(hWnd, &rctClient)
+
+    let hPrevFont = SelectObject(hDC, textfield.font?.hFont.value)
     _ = SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT))
     _ = SetBkMode(hDC, TRANSPARENT)
+
     _ = DrawTextW(hDC, placeholder.LPCWSTR, -1, &rctClient,
                   UINT(DT_EDITCONTROL | DT_NOCLIP | DT_NOPREFIX | DT_SINGLELINE | DT_VCENTER))
+
+    _ = SelectObject(hDC, hPrevFont)
+
 
     _ = ReleaseDC(hWnd, hDC)
 


### PR DESCRIPTION
When rendering the placeholder text, we need to swap out the font for
the drawing context to ensure that we get the proper font for the
rendering.  This also ensures that the placeholder is actually rendered
with the same text as the content.

Fixes: #318