### PR TITLE
UI: add focus based navigation types

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -81,6 +81,13 @@ target_sources(SwiftWin32 PRIVATE
   UI/Window.swift
   UI/WindowScene.swift)
 target_sources(SwiftWin32 PRIVATE
+  "UI/Focus-Based Navigation/FocusAnimationCoordinator.swift"
+  "UI/Focus-Based Navigation/FocusEnvironment.swift"
+  "UI/Focus-Based Navigation/FocusItem.swift"
+  "UI/Focus-Based Navigation/FocusItemContainer.swift"
+  "UI/Focus-Based Navigation/FocusMovementHint.swift"
+  "UI/Focus-Based Navigation/FocusUpdateContext.swift")
+target_sources(SwiftWin32 PRIVATE
   CA/Transform3D.swift)
 target_sources(SwiftWin32 PRIVATE
   CG/AffineTransform.swift

--- a/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusAnimationCoordinator.swift
+++ b/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusAnimationCoordinator.swift
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import struct Foundation.TimeInterval
+
+/// Information about focusing animations being performed by the system.
+public protocol FocusAnimationContext {
+  // MARK - Getting the Animation Attributes
+
+  /// The duration (measured in seconds) of the focus animation.
+  var duration: TimeInterval { get }
+}
+
+/// A coordinator of focus-related animations during a focus update.
+public class FocusAnimationCoordinator {
+  // MARK - Adding Animations to Focus Updates
+
+  /// Runs the specified set of animations together with the system animations
+  /// for adding focus to an item.
+  public func addCoordinatedFocusingAnimations(_ animations: ((FocusAnimationContext) -> Void)?,
+                                               completion: (() -> Void)? = nil) {
+  }
+
+  /// Runs the specified set of animations together with the system animations
+  /// for removing focus from an item.
+  public func addCoordinatedUnfocusingAnimations(_ animations: ((FocusAnimationContext) -> Void)?,
+                                                 completion: (() -> Void)? = nil) {
+  }
+
+  /// Specifies the animations to coordinate with the active focus animation.
+  public func addCoordinatedAnimations(_ animations: (() -> Void)?,
+                                       completion: (() -> Void)? = nil) {
+  }
+}

--- a/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusEnvironment.swift
+++ b/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusEnvironment.swift
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An identifier for a focus-related sound.
+public struct FocusSoundIdentifier: Equatable, Hashable, RawRepresentable {
+  public typealias RawValue = String
+
+  public let rawValue: RawValue
+
+  public init(rawValue: RawValue) {
+    self.rawValue = rawValue
+  }
+}
+
+extension FocusSoundIdentifier {
+  public init(_ rawValue: String) {
+    self.rawValue = rawValue
+  }
+}
+
+extension FocusSoundIdentifier {
+  /// The identifier for the default system sound to play during focus updates.
+  public static var `default`: FocusSoundIdentifier {
+    FocusSoundIdentifier(rawValue: "UIFocusSoundIdentifierDefault")
+  }
+
+  /// The identifier for disabling sound during a focus update.
+  public static var none: FocusSoundIdentifier {
+    FocusSoundIdentifier(rawValue: "UIFocusSoundIdentifierNone")
+  }
+}
+
+/// A set of methods that define the focus behavior for a branch of the view
+/// hierarchy.
+public protocol FocusEnvironment: AnyObject {
+  // MARK - Requesting Focus Update
+
+  /// Submits a request to the focus engine for a focus update in this
+  /// environment.
+  func setNeedsFocusUpdate()
+
+  /// Tells the focus engine to force a focus update immediately.
+  func updateFocusIfNeeded()
+
+  // MARK - Validating Focus Movements
+
+  /// Returns a boolean value indicating whether the focus engine should allow
+  /// the focus update described by the specified context to occur.
+  func shouldUpdateFocus(in context: FocusUpdateContext) -> Bool
+
+  // MARK - Responding to Focus Updates
+
+  /// Called immediately after the system updates the focus to a new view.
+  func didUpdateFocus(in context: FocusUpdateContext,
+                      with coordinator: FocusAnimationCoordinator)
+
+  // MARK - Controlling User Generated Focus Movements
+
+  /// An array of focus environments, ordered by priority, to which this
+  /// environment prefers focus to be directed during a focus update.
+  var preferredFocusEnvironments: [FocusEnvironment] { get }
+
+  // MARK - Getting the Sound to Play During Updates
+
+  /// Asks the delegate for the identifier of the sound to play when the object
+  /// gains focus.
+  func soundIdentifierForFocusUpdate(in context: FocusUpdateContext)
+      -> FocusSoundIdentifier?
+
+  // MARK - Checking the Ancestry of the Environment
+
+  /// Returns a boolean value indicating whether the focus environment contains
+  /// the specified environment.
+  func contains(_ environment: FocusEnvironment) -> Bool
+
+  /// The parent focus environment for this environment.
+  /* weak */ var parentFocusEnvironment: FocusEnvironment? { get }
+
+  /// The container for the child focus items in this focus environment.
+  var focusItemContainer: FocusItemContainer? { get }
+
+  // MARK -
+
+  var focusGroupIdentifier: String? { get }
+}
+
+extension FocusEnvironment {
+  public func soundIdentifierForFocusUpdate(in context: FocusUpdateContext)
+      -> FocusSoundIdentifier? {
+    return nil
+  }
+}
+
+extension FocusEnvironment {
+  public var focusGroupIdentifier: String? { nil }
+}

--- a/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusItem.swift
+++ b/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusItem.swift
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An object that can become focused.
+public protocol FocusItem: FocusEnvironment {
+  // MARK - Determining Focusability
+
+  /// A boolean value that indicates whether the item can become focused.
+  var canBecomeFocused: Bool { get }
+
+  /// A boolean value indicating whether the item is currently focused.
+  var isFocused: Bool { get }
+
+  // MARK - Retrieving the Item Frame
+
+  /// The geometric frame of the item.
+  var frame: Rect { get }
+
+  // MARK - Providing Movement Hints
+
+  func didHintFocusMovement(_ hint: FocusMovementHint)
+}
+
+extension FocusItem {
+  public var isFocused: Bool { false }
+}
+
+extension FocusItem {
+  public func didHintFocusMovement(_ hint: FocusMovementHint) {
+  }
+}

--- a/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusItemContainer.swift
+++ b/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusItemContainer.swift
@@ -1,0 +1,20 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// The container responsible for providing geometric context to focus items
+/// within a given focus environment.
+public protocol FocusItemContainer {
+  // MARK - Retrieving Focus Items
+
+  /// Retrieves all of the focus items within this container that intersect with
+  /// the provided rectangle.
+  func focusItems(in rect: Rect) -> [FocusItem]
+
+  /// The coordinate space of the focus items contained in the focus item
+  /// container.
+  var coordinateSpace: CoordinateSpace { get }
+}

--- a/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusMovementHint.swift
+++ b/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusMovementHint.swift
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// Provides movement hint information for the focused item.
+public class FocusMovementHint {
+  // MARK -
+
+  internal init () {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  // MARK - Moving Focus
+
+  /// A vector representing how close focus is to moving to another item in the
+  /// swiped direction.
+  public private(set) var movementDirection: Vector
+
+  // MARK - Transforming a Hint
+
+  /// A 3D transform that contains the combined transformations of perspective,
+  /// rotation, and translation.
+  public private(set) var interactionTransform: Transform3D
+
+  /// A 3D transform that represents a perspective matrix to be applied to match
+  /// the system interaction hinting.
+  public private(set) var perspectiveTransform: Transform3D
+
+  /// A vector to apply to a transform to match system interaction hinting.
+  public private(set) var rotation: Vector
+
+  /// A vector to apply to a transform to match system interaction hinting.
+  public private(set) var translation: Vector
+}

--- a/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusUpdateContext.swift
+++ b/Sources/SwiftWin32/UI/Focus-Based Navigation/FocusUpdateContext.swift
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import class Foundation.NSNotification
+
+/// The general type of an event.
+public struct FocusHeading: OptionSet {
+  public typealias RawValue = UInt
+
+  public let rawValue: RawValue
+
+  public init(rawValue: RawValue) {
+    self.rawValue = rawValue
+  }
+}
+
+extension FocusHeading {
+  internal static var none: FocusHeading {
+    FocusHeading(rawValue: 0 << 0)
+  }
+
+  /// The focus update is heading in the up direction.
+  public static var up: FocusHeading {
+    FocusHeading(rawValue: 1 << 0)
+  }
+
+  /// The focus update is heading in the down direction.
+  public static var down: FocusHeading {
+    FocusHeading(rawValue: 1 << 1)
+  }
+
+  /// The focus update is heading in the left direction.
+  public static var left: FocusHeading {
+    FocusHeading(rawValue: 1 << 2)
+  }
+
+  /// The focus update is heading in the right direction.
+  public static var right: FocusHeading {
+    FocusHeading(rawValue: 1 << 3)
+  }
+
+  /// The focus update is heading to the next item.
+  public static var next: FocusHeading {
+    FocusHeading(rawValue: 1 << 4)
+  }
+
+  /// The focus update is heading to the previous item.
+  public static var previous: FocusHeading {
+    FocusHeading(rawValue: 1 << 5)
+  }
+}
+
+/// An object that provides information relevant to a specific focus update from
+/// one view to another.
+public class FocusUpdateContext {
+  // MARK - Locating Focus Direction
+
+  /// The view that was focused before the focus update.
+  public private(set) weak var previouslyFocusedView: View?
+
+  /// The view that takes the focus after the focus update.
+  public private(set) weak var nextFocusedView: View?
+
+  /// The heading in which the focus update is occurring.
+  public private(set) var focusHeading: FocusHeading = .none
+
+  // MARK - Getting Related Focus Items
+
+  /// The item that was focused before the update.
+  public private(set) weak var previouslyFocusedItem: FocusItem?
+
+  /// The item to be focused after the update.
+  public private(set) weak var nextFocusedItem: FocusItem?
+
+  // MARK - Responding to Focus-Related Keys and Notifications
+
+  /// The focus for the UI has been updated.
+  public static var didUpdateNotification: NSNotification.Name {
+    NSNotification.Name(rawValue: "UIFocusUpdateContextDidUpdateNotification")
+  }
+
+  /// The focus failed to move to another item.
+  public static var movementDidFailNotification: NSNotification.Name {
+    NSNotification.Name(rawValue: "UIFocusUpdateContextMovementDidFailNotification")
+  }
+
+  /// Updates the animation coordinator.
+  public static var animationCoordinatorUserInfoKey: String {
+    "UIFocusUpdateContextAnimationCoordinatorUserInfoKey"
+  }
+
+  /// Updates the context key.
+  public static var focusUpdateContextUserInfoKey: String {
+    "UIFocusUpdateContextFocusUpdateContextUserInfoKey"
+  }
+}


### PR DESCRIPTION
This adds some of the basic structures for the focus based navigation
infrastructure.  This is meant to support navigation with alternate
input systems (e.g. gamepads).