### PR TITLE
CG: add `Vector` type

### DIFF
--- a/Sources/SwiftWin32/CG/Vector.swift
+++ b/Sources/SwiftWin32/CG/Vector.swift
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// A structure that contains a two-dimensional vector.
+public struct Vector {
+  // MARK - Special Values
+
+  /// The vector whose components are both zero.
+  static let zero: Vector = Vector(dx: 0.0, dy: 0.0)
+
+  /// Creates a vector whose components are both zero.
+  public init() {
+    self.dx = 0.0
+    self.dy = 0.0
+  }
+
+  // MARK - Geometric Properties
+
+  /// The x component of the vector.
+  public var dx: Double
+
+  /// The y component of the vector.
+  public var dy: Double
+
+  // MARK - Initializers
+
+  /// Creates a vector with components specified as floating-point values.
+  public init(dx: Double, dy: Double) {
+    self.dx = dx
+    self.dy = dy
+  }
+
+  /// Creates a vector with components specified as floating-point values.
+  public init(dx: Float, dy: Float) {
+    self.dx = Double(dx)
+    self.dy = Double(dy)
+  }
+
+  /// Creates a vector with components specified as integer values.
+  public init(dx: Int, dy: Int) {
+    self.dx = Double(dx)
+    self.dy = Double(dy)
+  }
+}
+
+extension Vector: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    return "(\(dx), \(dy))"
+  }
+}
+
+extension Vector: Decodable {
+}
+
+extension Vector: Encodable {
+}
+
+extension Vector: Equatable {
+}

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -84,7 +84,8 @@ target_sources(SwiftWin32 PRIVATE
   CG/AffineTransform.swift
   CG/Point.swift
   CG/Rect.swift
-  CG/Size.swift)
+  CG/Size.swift
+  CG/Vector.swift)
 target_sources(SwiftWin32 PRIVATE
   Platform/BatteryMonitor.swift
   Platform/Error.swift


### PR DESCRIPTION
Add the `Vector` type to represent a 2D vector.