### PR TITLE
UI: add editing interfaces to `TableViewCell`

### DIFF
--- a/Sources/SwiftWin32/UI/TableViewCell.swift
+++ b/Sources/SwiftWin32/UI/TableViewCell.swift
@@ -26,6 +26,22 @@ extension TableViewCell {
   }
 }
 
+extension TableViewCell {
+  /// The editing control used by a cell.
+  public enum EditingStyle: Int {
+  /// The cell has no editing control. This is the default value.
+  case none
+
+  /// The cell has the delete editing control; this control is a red circle
+  /// enclosing a minus sign.
+  case delete
+
+  /// The cell has the insert editing control; this control is a green circle
+  /// enclosing a plus sign.
+  case insert
+  }
+}
+
 /// The visual representation of a single row in a table view.
 public class TableViewCell: View {
   private static let `class`: WindowClass =
@@ -35,7 +51,7 @@ public class TableViewCell: View {
                   hCursor: LoadCursorW(nil, IDC_ARROW))
   private static let style: WindowStyle = (base: 0, extended: 0)
 
-  /// Creating a Table View Cell
+  // MARK - Creating a Table View Cell
 
   /// Initializes a table cell with a style and a reuse identifier and returns it
   /// to the caller.
@@ -45,12 +61,36 @@ public class TableViewCell: View {
                style: TableViewCell.style)
   }
 
-  /// Reusing Cells
+  // MARK - Reusing Cells
 
   /// A string used to identify a cell that is reusable.
   public let reuseIdentifier: String?
 
   /// Prepares a reusable cell for reuse by the table view's delegate.
   public func prepareForReuse() {
+  }
+
+  // MARK - Editing the Cell
+
+  /// A boolean value that indicates whether the cell is in an editable state.
+  public var isEditing: Bool = false
+
+  /// Toggles the receiver into and out of editing mode.
+  public func setEditing(_ editing: Bool, animated: Bool) {
+    assert(!animated, "not yet implemented")
+    self.isEditing = editing
+  }
+
+  /// The editing style of the cell.
+  public private(set) var editingStyle: TableViewCell.EditingStyle = .none
+
+  /// A boolean value that indicates whether the cell is currently showing the
+  /// delete-confirmation button.
+  public private(set) var showingDeleteConfirmation: Bool = false
+
+  /// A boolean value that determines whether the cell shows the reordering
+  /// control.
+  public var showsReorderControl: Bool = false {
+    didSet { fatalError("\(#function) not yet implemented") }
   }
 }


### PR DESCRIPTION
Add the interfaces to control the editing state of a `TableViewCell`.