### PR TITLE
UI: add `PointerInteraction` structures

### DIFF
--- a/Sources/SwiftWin32/UI/Axis.swift
+++ b/Sources/SwiftWin32/UI/Axis.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// Defines a structure that specifies the layout axes.
+public struct Axis: OptionSet {
+  public typealias RawValue = UInt
+
+  public let rawValue: RawValue
+
+  // MARK - Initializers
+
+  public init(rawValue: RawValue) {
+    self.rawValue = rawValue
+  }
+}
+
+extension Axis {
+  public static var both: Axis {
+    [.horizontal, .vertical]
+  }
+
+  public static var horizontal: Axis {
+    Axis(rawValue: 1 << 0)
+  }
+
+  public static var vertical: Axis {
+    Axis(rawValue: 1 << 1)
+  }
+}

--- a/Sources/SwiftWin32/UI/PointerInteraction.swift
+++ b/Sources/SwiftWin32/UI/PointerInteraction.swift
@@ -1,0 +1,44 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An interaction that enables support for effects on a view or customizes the
+/// pointer's appearance within a region of an app.
+public class PointerInteraction {
+  // MARK - Creating Pointer Interactions
+
+  /// Initializes a pointer interaction object with a specified delegate object.
+  public init(delegate: PointerInteractionDelegate?) {
+    self.delegate = delegate
+  }
+
+  // MARK - Managing Pointer Interactions
+
+  /// An object that responds to pointer movements.
+  public private(set) weak var delegate: PointerInteractionDelegate?
+
+  // MARK - Activating Pointer Interactions
+
+  /// A boolean value that indicates whether the pointer interaction is enabled.
+  public var isEnabled: Bool = true
+
+  // MARK - Triggering a Pointer Update
+
+  /// Causes the interaction to update the pointer in response to an event.
+  public func invalidate() {
+  }
+
+  // MARK - Interaction
+  public private(set) weak var view: View?
+}
+
+extension PointerInteraction: Interaction {
+  public func didMove(to view: View?) {
+  }
+
+  public func willMove(to view: View?) {
+  }
+}

--- a/Sources/SwiftWin32/UI/PointerInteractionAnimating.swift
+++ b/Sources/SwiftWin32/UI/PointerInteractionAnimating.swift
@@ -1,0 +1,18 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An interface for modifying an interaction animation in coordination with the
+/// pointer effect animations.
+public protocol PointerInteractionAnimating {
+  // MARK - Managing Animations
+
+  /// Adds the specified animation block to the animator.
+  func addAnimations(_ animations: @escaping () -> Void)
+
+  /// Adds the specified completion block to the animator.
+  func addCompletion(_ completion: @escaping (Bool) -> Void)
+}

--- a/Sources/SwiftWin32/UI/PointerInteractionDelegate.swift
+++ b/Sources/SwiftWin32/UI/PointerInteractionDelegate.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An interface for handling pointer movements within the interaction's view.
+public protocol PointerInteractionDelegate: AnyObject {
+  // MARK - Defining Pointer Styles for Regions
+
+  /// Asks the delegate for a region as the pointer moves within the
+  /// interaction's view.
+  func pointerInteraction(_ interaction: PointerInteraction,
+                          regionFor request: PointerRegionRequest,
+                          defaultRegion: PointerRegion) -> PointerRegion?
+
+  /// Asks the delegate for a pointer style after an interaction receives a new
+  /// region.
+  func pointerInteraction(_ interaction: PointerInteraction,
+                          styleFor region: PointerRegion) -> PointerStyle?
+
+  // MARK - Handling Animations for Pointer Regions
+
+  /// Informs the delegate when the pointer enters a given region.
+  func pointerInteraction(_ interaction: PointerInteraction,
+                          willEnter region: PointerRegion,
+                          animator: PointerInteractionAnimating)
+
+  /// Informs the delegate when the pointer exits a given region.
+  func pointerInteraction(_ interaction: PointerInteraction,
+                          willExit region: PointerRegion,
+                          animator: PointerInteractionAnimating)
+}
+
+extension PointerInteractionDelegate {
+  public func pointerInteraction(_ interaction: PointerInteraction,
+                                 regionFor request: PointerRegionRequest,
+                                 defaultRegion: PointerRegion)
+      -> PointerRegion? {
+    return nil
+  }
+
+  public func pointerInteraction(_ interaction: PointerInteraction,
+                                 styleFor region: PointerRegion)
+      -> PointerStyle? {
+    return nil
+  }
+}
+
+extension PointerInteractionDelegate {
+  public func pointerInteraction(_ interaction: PointerInteraction,
+                                 willEnter region: PointerRegion,
+                                 animator: PointerInteractionAnimating) {
+  }
+
+  public func pointerInteraction(_ interaction: PointerInteraction,
+                                 willExit region: PointerRegion,
+                                 animator: PointerInteractionAnimating) {
+  }
+}

--- a/Sources/SwiftWin32/UI/PointerRegion.swift
+++ b/Sources/SwiftWin32/UI/PointerRegion.swift
@@ -1,0 +1,24 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+public class PointerRegion {
+  // MARK - Configuring a Region
+
+  /// The rectangle bounds of the region.
+  public private(set) var rect: Rect
+
+  // MARK - Initializers
+
+  public /*convenience*/ init(rect: Rect, identifier: AnyHashable? = nil) {
+    self.rect = rect
+    self.identifier = identifier
+  }
+
+  // MARK - Instance Property
+
+  public private(set) var identifier: AnyHashable?
+}

--- a/Sources/SwiftWin32/UI/PointerRegionRequest.swift
+++ b/Sources/SwiftWin32/UI/PointerRegionRequest.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An object to describe the pointer's location in the interaction's view.
+public class PointerRegionRequest {
+  // MARK - Inspecting the Region Request
+
+  /// The location of the pointer in the interaction's view's coordinate space.
+  public private(set) var location: Point
+
+  /// Key modifier flags representing keyboard keys pressed by the user at the
+  /// time of this request.
+  public private(set) var modifiers: KeyModifierFlags
+
+  internal init(location: Point, modifiers: KeyModifierFlags) {
+    self.location = location
+    self.modifiers = modifiers
+  }
+}

--- a/Sources/SwiftWin32/UI/PointerStyle.swift
+++ b/Sources/SwiftWin32/UI/PointerStyle.swift
@@ -1,0 +1,112 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+extension PointerEffect {
+  /// An effect that defines how to apply a tint to a view during a pointer
+  /// interaction.
+  public enum TintMode: Hashable {
+    // MARK - Tint Modes
+
+    /// The view has no tint applied.
+    case none
+
+    /// The view has a tint overlay.
+    case overlay
+
+    /// The view has a tint underlay.
+    case underlay
+  }
+}
+
+/// An effect that alters a view's appearance when a pointer enters the current
+/// region.
+public enum PointerEffect {
+  // MARK - Accessing the Preview
+
+  /// A preview of the view used during an interaction's animations.
+  public var preview: TargetedPreview {
+    switch self {
+    case .automatic(let preview):
+      return preview
+    case .highlight(let preview):
+      return preview
+    case .hover(let preview, _, _, _):
+      return preview
+    case .lift(let preview):
+      return preview
+    }
+  }
+
+  // MARK - Creating a Default Effect
+
+  /// A pointer content effect with the given preview's view.
+  case automatic(TargetedPreview)
+
+  // MARK - Creating a Specific Effect
+
+  /// An effect where the pointer slides under the given view and morphs into
+  /// the view's shape.
+  case highlight(TargetedPreview)
+
+  /// An effect where visual changes are applied to the view and the pointer
+  /// retains its default shape.
+  case hover(TargetedPreview,
+             preferredTintMode: PointerEffect.TintMode = .overlay,
+             prefersShadow: Bool = false,
+             prefersScaledContent: Bool = true)
+
+  /// An effect where the pointer slides under the given view and disappears as
+  /// the view scales up and gains a shadow.
+  case lift(TargetedPreview)
+}
+
+/// An object that defines the shape of custom pointers.
+public enum PointerShape {
+  // MARK - Specifying Pointer Shapes
+
+  /// The pointer morphs into a horizontal beam using the specified length.
+  case horizontalBeam(length: Double)
+
+  /// The pointer morphs into a vertical beam using the specified length.
+  case verticalBeam(length: Double)
+
+  /// The pointer morphs into the given Bézier path.
+  case path(BezierPath)
+
+  /// The pointer morphs into a rounded rectangle using the provided corner
+  /// radius.
+  case roundedRect(Rect, radius: Double = PointerShape.defaultCornerRadius)
+
+  // MARK - Accessing Corner Radius
+
+  /// The default corner radius for a pointer using a rounded rectangle.
+  public static var defaultCornerRadius: Double {
+    8.0
+  }
+}
+
+/// An object that defines the pointer shape and effect.
+public class PointerStyle {
+  // MARK - Creating a Pointer Style
+
+  /// Applies the provided content effect and pointer shape to the current
+  /// region.
+  public convenience init(effect: PointerEffect, shape: PointerShape? = nil) {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  /// Morphs the pointer into the provided shape when hovering over the current
+  /// region.
+  public convenience init(shape: PointerShape, constrainedAxes: Axis = []) {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  /// Hides the pointer when it moves over the current region.
+  public class func hidden() -> Self {
+    fatalError("\(#function) not yet implemented")
+  }
+}


### PR DESCRIPTION
This starts adding some of the structure necessary to specialise the
interactions for pointers and touch interfaces simultaneously.