### PR TITLE
Table View: compute the cell size automatically

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -183,7 +183,6 @@ extension UICatalog: TableViewDataSource {
     let cell = TableViewCell(style: .default, reuseIdentifier: nil)
     cell.addSubview(Button(frame: Rect(x: 0, y: 0, width: 80, height: 32),
                            title: "Button \(indexPath.row)"))
-    cell.frame = Rect(x: 0, y: 0, width: 80, height: 32)
     return cell
   }
 }

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -48,12 +48,8 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
 
     if let view = unsafeBitCast(lpMeasurement.pointee.itemData,
                                 to: AnyObject.self) as? View {
-      var r: RECT = RECT()
-      _ = GetClientRect(view.hWnd, &r)
-      var client: Rect = Rect(from: r)
-
-      lpMeasurement.pointee.itemHeight = UINT(client.size.height)
-      lpMeasurement.pointee.itemWidth = UINT(client.size.width)
+      lpMeasurement.pointee.itemHeight = UINT(view.frame.size.height)
+      lpMeasurement.pointee.itemWidth = UINT(view.frame.size.width)
     }
 
     return LRESULT(1)
@@ -151,6 +147,9 @@ public class TableView: View {
             dataSource.tableView(self,
                                  cellForRowAt: IndexPath(row: row,
                                                          section: section))
+        // Resize the frame to the size that fits the content
+        cell.frame.size = cell.sizeThatFits(cell.frame.size)
+
         _ = SendMessageW(self.hWnd, UINT(LB_INSERTSTRING),
                          WPARAM(bitPattern: -1),
                          unsafeBitCast(cell as AnyObject, to: LPARAM.self))

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewCell.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewCell.swift
@@ -51,6 +51,11 @@ public class TableViewCell: View {
                   hCursor: LoadCursorW(nil, IDC_ARROW))
   private static let style: WindowStyle = (base: 0, extended: 0)
 
+  public override func sizeThatFits(_ size: Size) -> Size {
+    // TODO(compnerd) this should size the content view
+    return self.subviews.first?.sizeThatFits(size) ?? .zero
+  }
+
   // MARK - Creating a Table View Cell
 
   /// Initializes a table cell with a style and a reuse identifier and returns it


### PR DESCRIPTION
Compute the frame for the cell at runtime when the cell is populated.
This allows us to dynamically size for the content.