### PR TITLE
AutoLayout: convert stored properties into computed properties

### DIFF
--- a/Sources/SwiftWin32/AutoLayout/LayoutPriority.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutPriority.swift
@@ -27,31 +27,38 @@ extension LayoutPriority {
 
 extension LayoutPriority {
   /// A required constraint.
-  public static let required: LayoutPriority =
-      LayoutPriority(rawValue: 1000.0)
+  public static var required: LayoutPriority {
+    LayoutPriority(rawValue: 1000.0)
+  }
 
   /// The priority level with which a button resists compressing its content.
-  public static let defaultHigh: LayoutPriority =
-      LayoutPriority(rawValue: 750.0)
+  public static var defaultHigh: LayoutPriority {
+    LayoutPriority(rawValue: 750.0)
+  }
 
   /// The priority level with which a button hugs its contents horizontally.
-  public static let defaultLow: LayoutPriority =
-      LayoutPriority(rawValue: 250.0)
+  public static var defaultLow: LayoutPriority {
+    LayoutPriority(rawValue: 250.0)
+  }
 
   /// The priority level with which the view wants to conform to the target size
   /// in that computation.
-  public static let fittingSizeLevel: LayoutPriority =
-      LayoutPriority(rawValue: 50.0)
+  public static var fittingSizeLevel: LayoutPriority {
+    LayoutPriority(rawValue: 50.0)
+  }
 
   /// The priority with which a drag may end up resizing the window's scene.
-  public static let dragThatCanResizeScene: LayoutPriority =
-      LayoutPriority(rawValue: 510.0)
+  public static var dragThatCanResizeScene: LayoutPriority {
+    LayoutPriority(rawValue: 510.0)
+  }
 
   /// The priority with which the a split view divider is dragged.
-  public static let dragThatCannotResizeScene: LayoutPriority =
-      LayoutPriority(rawValue: 490.0)
+  public static var dragThatCannotResizeScene: LayoutPriority {
+    LayoutPriority(rawValue: 490.0)
+  }
 
   /// The priority with which the window's scene prefers to stay the same size.
-  public static let sceneSizeStayPut: LayoutPriority =
-      LayoutPriority(rawValue: 500.0)
+  public static var sceneSizeStayPut: LayoutPriority {
+    LayoutPriority(rawValue: 500.0)
+  }
 }


### PR DESCRIPTION
Use computed properties for the constants rather than stored properties.
The values are completely trivial and the storage is unnecessary.