### PR TITLE
Windows and Screens: adjust notification name

### DIFF
--- a/Sources/SwiftWin32/Windows and Screens/Window.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Window.swift
@@ -210,7 +210,7 @@ public class Window: View {
 extension Window {
   /// Posted whn a `Window` object becomes visible.
   public class var didBecomeVisibleNotification: NSNotification.Name {
-    NSNotification.Name(rawValue: "UIWindowDIdBecomeVisibleNotification")
+    NSNotification.Name(rawValue: "UIWindowDidBecomeVisibleNotification")
   }
 
   /// Posted when a `Window` object becomes hidden.


### PR DESCRIPTION
Correct the case for the notification name.  No functional change.