### PR TITLE
Fix for compnerd/swift-win32/issues/272

### DIFF
--- a/Examples/Calculator/CMakeLists.txt
+++ b/Examples/Calculator/CMakeLists.txt
@@ -2,7 +2,9 @@ add_executable(Calculator
   Calculator.swift)
 add_custom_command(TARGET Calculator POST_BUILD
   COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Calculator.exe.manifest $<TARGET_FILE_DIR:Calculator>)
+    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Calculator.exe.manifest $<TARGET_FILE_DIR:Calculator>
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist $<TARGET_FILE_DIR:Calculator>)
 # FIXME(SR-12683) `@main` requires `-parse-as-library`
 target_compile_options(Calculator PRIVATE
   -parse-as-library)

--- a/Sources/SwiftWin32UI/Essentials/Application.swift
+++ b/Sources/SwiftWin32UI/Essentials/Application.swift
@@ -27,7 +27,6 @@ public protocol Application {
 extension Application {
   /// Initializes and runs the application.
   public static func main() {
-    ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil,
-                    String(describing: String(reflecting: Self.self)))
+    ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil)
   }
 }


### PR DESCRIPTION
- Application main loads the delegate name from info.plist
- main: remove delegate param since it's loaded from info.plist
- Calculator: copy info.plist in CMakeLists (calculator exe was not loading before that)