### PR TITLE
Calculator: fix missing info.plist

### DIFF
--- a/Examples/Calculator/CMakeLists.txt
+++ b/Examples/Calculator/CMakeLists.txt
@@ -2,7 +2,9 @@ add_executable(Calculator
   Calculator.swift)
 add_custom_command(TARGET Calculator POST_BUILD
   COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Calculator.exe.manifest $<TARGET_FILE_DIR:Calculator>)
+    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Calculator.exe.manifest $<TARGET_FILE_DIR:Calculator>
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist $<TARGET_FILE_DIR:Calculator>)
 # FIXME(SR-12683) `@main` requires `-parse-as-library`
 target_compile_options(Calculator PRIVATE
   -parse-as-library)


### PR DESCRIPTION
- Before the fix: The calculator app build successfully but does not show any window
- Cause: info.plist was not copied into ?binary?
- The fix: the info plist copy command is added to calculator's CMakeLists.txt. CMakeCache needs to be invalidated.