### PR TITLE
UI: make stepper subclass handling safer

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Stepper.swift
+++ b/Sources/SwiftWin32/Views and Controls/Stepper.swift
@@ -28,9 +28,9 @@ private let SwiftStepperWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lParam) in
     let lpInstance = GetWindowLongPtrW(hSender, GWLP_USERDATA)
     if lpInstance == 0 { break }
 
-    let stepper: Stepper! =
-        unsafeBitCast(lpInstance, to: AnyObject.self) as? Stepper
-    stepper.sendActions(for: .valueChanged)
+    if let stepper = unsafeBitCast(lpInstance, to: AnyObject.self) as? Stepper {
+      stepper.sendActions(for: .valueChanged)
+    }
   default:
     break
   }


### PR DESCRIPTION
Rather than force unwrapping the parameter, silently drop the message if
the value is unexpectedly missing.