### PR TITLE
UI: avoid circular references

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -338,13 +338,13 @@ public class View: Responder {
   // MARK - Managing the View Hierarchy
 
   /// The receiver's superview, or `nil` if it has none.
-  public private(set) var superview: View?
+  public private(set) weak var superview: View?
 
   /// The receiver's immediate subviews.
   public private(set) var subviews: [View] = []
 
   /// The receiver's window object, or `nil` if it has none.
-  public private(set) var window: Window?
+  public private(set) weak var window: Window?
 
   /// Add a subview to the end of the reciever's list of subviews.
   public func addSubview(_ view: View) {


### PR DESCRIPTION
The parent view has a strong reference to the child view.  However, the
child view also has a strong reference to the parent.  This constructs a
circular reference.  Make the parent reference weak as the parent window
owns the child.  We similarly want to avoid the strong reference to the
Window object as the Window object owns the reference to the views.