### PR TITLE
Application: rename `NSPrincipalClass` to `PrincipalClass`

### DIFF
--- a/Sources/SwiftWin32/Application/Information.swift
+++ b/Sources/SwiftWin32/Application/Information.swift
@@ -47,6 +47,6 @@ extension Application {
 extension Application.Information: Decodable {
   enum CodingKeys: String, CodingKey {
     case scene = "ApplicationSceneManifest"
-    case principalClass = "NSPrincipalClass"
+    case principalClass = "PrincipalClass"
   }
 }


### PR DESCRIPTION
The options keys in `Info.plist` nor the classes in the framework
currently are not prefixed.  Follow suit to make everything more
consistent.