### PR TITLE
SwiftUI: add a default implementation for `body`

### DIFF
--- a/Sources/SwiftWin32UI/EmptyView.swift
+++ b/Sources/SwiftWin32UI/EmptyView.swift
@@ -9,10 +9,6 @@
 public struct EmptyView: View {
   public typealias Body = Never
 
-  public var body: Self.Body {
-    fatalError("\(#function) not yet implemented")
-  }
-
   @inlinable
   public init() {
   }

--- a/Sources/SwiftWin32UI/Never+SwiftUI.swift
+++ b/Sources/SwiftWin32UI/Never+SwiftUI.swift
@@ -13,8 +13,10 @@ extension Never: Scene {
 
 extension Never {
   public typealias Body = Never
+}
 
+extension View where Body == Never {
   public var body: Never {
-    fatalError("\(#function) not yet implemented")
+    fatalError("\(#function): View \(type(of: self)) does not have a body")
   }
 }


### PR DESCRIPTION
For the case where the `Body` type is `Never`, we can simply synthesize
the default member for the `View` type.