### PR TITLE
SwiftWin32: silence an annoying warning

### DIFF
--- a/Sources/SwiftWin32/Text Display and Fonts/FontMetrics.swift
+++ b/Sources/SwiftWin32/Text Display and Fonts/FontMetrics.swift
@@ -44,7 +44,7 @@ public class FontMetrics {
   public func scaledFont(for font: Font, maximumPointSize: Double,
                          compatibleWith traitCollection: TraitCollection?)
       -> Font {
-    let traitCollection = traitCollection ?? TraitCollection.current
+    let _ = traitCollection ?? TraitCollection.current
     // TODO(compnerd) adjust the font size for the trait collection and cap the
     // size.
     fatalError("\(#function) not yet implemented")


### PR DESCRIPTION
`traitCollection` is currently used as
`FontMetrics.scaledFont(for:maximumPointSize:compatibleWith:)` is not
yet implemented.  Silence the warning by assigning the result to the
blackhole.