### PR TITLE
Appearance Customization: split out `ConfigurationStateCustomKey`

### DIFF
--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationState.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationState.swift
@@ -5,23 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-/// A key that defines a custom state for a view.
-public struct ConfigurationStateCustomKey: Equatable, Hashable, RawRepresentable {
-  public typealias RawValue = String
-
-  public let rawValue: RawValue
-
-  public init(rawValue: String) {
-    self.rawValue = rawValue
-  }
-}
-
-extension ConfigurationStateCustomKey {
-  public init(_ rawValue: String) {
-    self.rawValue = rawValue
-  }
-}
-
 /// The requirements for an object that encapsulate a view's state.
 public protocol ConfigurationState {
   // MARK - Managing Configuration States

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationStateCustomKey.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationStateCustomKey.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// A key that defines a custom state for a view.
+public struct ConfigurationStateCustomKey: Equatable, Hashable, RawRepresentable {
+  public typealias RawValue = String
+
+  public let rawValue: RawValue
+
+  public init(rawValue: RawValue) {
+    self.rawValue = rawValue
+  }
+}
+
+extension ConfigurationStateCustomKey {
+  public init(_ rawValue: String) {
+    self.rawValue = rawValue
+  }
+}

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -38,7 +38,8 @@ target_sources(SwiftWin32 PRIVATE
   "Appearance Customization/Configurations/BackgroundConfiguration.swift"
   "Appearance Customization/Configurations/CellConfigurationState.swift"
   "Appearance Customization/Configurations/ConfigurationColorTransformer.swift"
-  "Appearance Customization/Configurations/ConfigurationState.swift")
+  "Appearance Customization/Configurations/ConfigurationState.swift"
+  "Appearance Customization/Configurations/ConfigurationStateCustomKey.swift")
 target_sources(SwiftWin32 PRIVATE
   "Drag and Drop/SpringLoadedInteractionContext.swift")
 target_sources(SwiftWin32 PRIVATE


### PR DESCRIPTION
Split out the definition to a standalone file.