### PR TITLE
Swift/Win32: rename `LPCWSTR` to `wide`

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -163,8 +163,8 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
   }
 
   private func pressMe(_: Button?) {
-    MessageBoxW(nil, "Swift/Win32 Demo!".LPCWSTR,
-                "Swift/Win32 MessageBox!".LPCWSTR, UINT(MB_OK))
+    MessageBoxW(nil, "Swift/Win32 Demo!".wide,
+                "Swift/Win32 MessageBox!".wide, UINT(MB_OK))
   }
 
   private func stepperValueDidChange(_ stepper: Stepper) {

--- a/Sources/SwiftWin32/App and Environment/Device.swift
+++ b/Sources/SwiftWin32/App and Environment/Device.swift
@@ -32,8 +32,8 @@ public struct Device {
       var cbData: DWORD = DWORD(szBuffer.count * MemoryLayout<WCHAR>.size)
       let lStatus: LSTATUS =
           RegGetValueW(HKEY_LOCAL_MACHINE,
-                       "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion".LPCWSTR,
-                       "ProductName".LPCWSTR,
+                       "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion".wide,
+                       "ProductName".wide,
                        DWORD(RRF_RT_REG_SZ | RRF_ZEROONFAILURE),
                        nil, &szBuffer, &cbData)
       if lStatus == ERROR_MORE_DATA {
@@ -55,8 +55,8 @@ public struct Device {
       var cbData: DWORD = DWORD(szBuffer.count * MemoryLayout<WCHAR>.size)
       let lStatus: LSTATUS =
           RegGetValueW(HKEY_LOCAL_MACHINE,
-                       "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion".LPCWSTR,
-                       "CurrentBuildNumber".LPCWSTR,
+                       "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion".wide,
+                       "CurrentBuildNumber".wide,
                        DWORD(RRF_RT_REG_SZ | RRF_ZEROONFAILURE),
                        nil, &szBuffer, &cbData)
       if lStatus == ERROR_MORE_DATA {

--- a/Sources/SwiftWin32/App and Environment/TraitCollection.swift
+++ b/Sources/SwiftWin32/App and Environment/TraitCollection.swift
@@ -119,8 +119,8 @@ private func GetCurrentColorScheme() -> UserInterfaceStyle {
 
   let lStatus: LSTATUS =
       RegGetValueW(HKEY_CURRENT_USER,
-                   "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize".LPCWSTR,
-                   "AppsUseLightTheme".LPCWSTR,
+                   "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize".wide,
+                   "AppsUseLightTheme".wide,
                    DWORD(RRF_RT_REG_DWORD), nil,
                    &dwAppsUseLightTheme, &cbAppsUseLightTheme)
   guard lStatus == S_OK else {

--- a/Sources/SwiftWin32/Application/ApplicationMain.swift
+++ b/Sources/SwiftWin32/Application/ApplicationMain.swift
@@ -45,7 +45,7 @@ public func ApplicationMain(_ argc: Int32,
                             _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>,
                             _ application: String?,
                             _ delegate: String?) -> Int32 {
-  let hRichEdit: HMODULE? = LoadLibraryW("msftedit.dll".LPCWSTR)
+  let hRichEdit: HMODULE? = LoadLibraryW("msftedit.dll".wide)
   if hRichEdit == nil {
     log.error("unable to load `msftedit.dll`: \(Error(win32: GetLastError()))")
   }

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -136,6 +136,7 @@ target_sources(SwiftWin32 PRIVATE
   Platform/WindowClass.swift
   Platform/WindowsHandle.swift)
 target_sources(SwiftWin32 PRIVATE
+  Support/Array+Extensions.swift
   Support/IndexPath+UIExtensions.swift
   Support/Logging.swift
   Support/Rect+UIExtensions.swift

--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuElement.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuElement.swift
@@ -78,7 +78,7 @@ internal class Win32MenuElement {
   internal var info: MENUITEMINFOW
 
   private init(title: String, image: Image?, submenu: Win32Menu?, fType: Int32) {
-    self.title = title.LPCWSTR
+    self.title = title.wide
     self.submenu = submenu
 
     let imageHandle: BitmapHandle?

--- a/Sources/SwiftWin32/Platform/PropertyWrappers.swift
+++ b/Sources/SwiftWin32/Platform/PropertyWrappers.swift
@@ -28,7 +28,7 @@ public struct _Win32WindowText {
       return String(decodingCString: buffer, as: UTF16.self)
     }
     set(value) {
-      SetWindowTextW(view.hWnd, value?.LPCWSTR)
+      SetWindowTextW(view.hWnd, value?.wide)
     }
   }
 

--- a/Sources/SwiftWin32/Platform/WindowClass.swift
+++ b/Sources/SwiftWin32/Platform/WindowClass.swift
@@ -21,7 +21,7 @@ internal class WindowClass {
               WindowProc lpfnWindowProc: WindowProc? = DefWindowProcW,
               style: UInt32 = 0, hbrBackground: HBRUSH? = nil,
               hCursor: HCURSOR? = nil) {
-    self.name = name.LPCWSTR
+    self.name = name.wide
 
     self.hInstance = hInstance
     self.name.withUnsafeBufferPointer {
@@ -41,7 +41,7 @@ internal class WindowClass {
   }
 
   public init(named: String) {
-    self.name = named.LPCWSTR
+    self.name = named.wide
   }
 
   public func register() -> Bool {

--- a/Sources/SwiftWin32/Support/Array+Extensions.swift
+++ b/Sources/SwiftWin32/Support/Array+Extensions.swift
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import ucrt
+
+extension Array where Element == UInt16 {
+  internal init(from string: String) {
+    self = string.withCString(encodedAs: UTF16.self) { buffer in
+      Array<UInt16>(unsafeUninitializedCapacity: string.utf16.count + 1) {
+        wcscpy_s($0.baseAddress, $0.count, buffer)
+        $1 = $0.count
+      }
+    }
+  }
+}

--- a/Sources/SwiftWin32/Support/Logging.swift
+++ b/Sources/SwiftWin32/Support/Logging.swift
@@ -14,31 +14,31 @@ import WinSDK
 
 internal struct log {
   static func trace(_ message: String) {
-    OutputDebugStringW("TRACE: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("TRACE: \(message)\r\n".wide)
   }
 
   static func debug(_ message: String) {
-    OutputDebugStringW("DEBUG: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("DEBUG: \(message)\r\n".wide)
   }
 
   static func info(_ message: String) {
-    OutputDebugStringW("INFO: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("INFO: \(message)\r\n".wide)
   }
 
   static func notice(_ message: String) {
-    OutputDebugStringW("NOTICE: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("NOTICE: \(message)\r\n".wide)
   }
 
   static func error(_ message: String) {
-    OutputDebugStringW("ERROR: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("ERROR: \(message)\r\n".wide)
   }
 
   static func warning(_ message: String) {
-    OutputDebugStringW("WARNING: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("WARNING: \(message)\r\n".wide)
   }
 
   static func critical(_ message: String) {
-    OutputDebugStringW("CRITICAL: \(message)\r\n".LPCWSTR)
+    OutputDebugStringW("CRITICAL: \(message)\r\n".wide)
   }
 }
 #endif

--- a/Sources/SwiftWin32/Support/String+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/String+UIExtensions.swift
@@ -5,16 +5,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
-import ucrt
-
-public extension String {
-  var LPCWSTR: [UInt16] {
-    return self.withCString(encodedAs: UTF16.self) { buffer in
-      Array<UInt16>(unsafeUninitializedCapacity: self.utf16.count + 1) {
-        wcscpy_s($0.baseAddress, $0.count, buffer)
-        $1 = $0.count
-      }
+extension String {
+  internal init(from utf16: [UInt16]) {
+    self = utf16.withUnsafeBufferPointer {
+      String(decodingCString: $0.baseAddress!, as: UTF16.self)
     }
+  }
+}
+
+extension String {
+  public var wide: [UInt16] {
+    return Array<UInt16>(from: self)
   }
 }
 

--- a/Sources/SwiftWin32/Text Display and Fonts/Font.swift
+++ b/Sources/SwiftWin32/Text Display and Fonts/Font.swift
@@ -220,7 +220,7 @@ public class Font {
                                                 DWORD(CLIP_DEFAULT_PRECIS),
                                                 DWORD(DEFAULT_QUALITY),
                                                 DWORD((FF_DONTCARE << 2) | DEFAULT_PITCH),
-                                                name.LPCWSTR))
+                                                name.wide))
   }
 
   // public init(descriptor: FontDescriptor, size pointSize: Double)
@@ -369,7 +369,7 @@ public class Font {
     }
 
     _ = withUnsafeMutablePointer(to: &arrFonts) {
-      EnumFontsW(hDC, family.LPCWSTR, pfnEnumerateFonts,
+      EnumFontsW(hDC, family.wide, pfnEnumerateFonts,
                  LPARAM(Int(bitPattern: $0)))
     }
     return Array<String>(arrFonts)
@@ -465,7 +465,7 @@ public class Font {
     let _ = SelectObject(hDC.value, self.hFont.value)
 
     var size: SIZE = SIZE()
-    if !GetTextExtentPoint32W(hDC.value, "u{0048}".LPCWSTR, 1, &size) {
+    if !GetTextExtentPoint32W(hDC.value, "u{0048}".wide, 1, &size) {
       log.warning("GetTextExtentPoint32W: \(Error(win32: GetLastError()))")
       return 0.0
     }
@@ -479,7 +479,7 @@ public class Font {
     let _ = SelectObject(hDC.value, self.hFont.value)
 
     var size: SIZE = SIZE()
-    if !GetTextExtentPoint32W(hDC.value, "u{0078}".LPCWSTR, 1, &size) {
+    if !GetTextExtentPoint32W(hDC.value, "u{0078}".wide, 1, &size) {
       log.warning("GetTextExtentPoint32W: \(Error(win32: GetLastError()))")
       return 0.0
     }
@@ -545,7 +545,7 @@ public class Font {
                                     DWORD(CLIP_DEFAULT_PRECIS),
                                     DWORD(DEFAULT_QUALITY),
                                     DWORD((FF_DONTCARE << 2) | DEFAULT_PITCH),
-                                    fontName.LPCWSTR))
+                                    fontName.wide))
   }
 }
 

--- a/Sources/SwiftWin32/View Controllers/ViewController.swift
+++ b/Sources/SwiftWin32/View Controllers/ViewController.swift
@@ -103,7 +103,7 @@ public class ViewController: Responder {
       }
       return String(decodingCString: buffer, as: UTF16.self)
     }
-    set(value) { _ = SetWindowTextW(view.hWnd, value?.LPCWSTR) }
+    set(value) { _ = SetWindowTextW(view.hWnd, value?.wide) }
   }
 
   /// The preferred size for the view controller's view.

--- a/Sources/SwiftWin32/Views and Controls/Button.swift
+++ b/Sources/SwiftWin32/Views and Controls/Button.swift
@@ -39,6 +39,6 @@ public class Button: Control {
 
   // FIXME(compnerd) handle title setting for different states
   public func setTitle(_ title: String?, forState _: Control.State) {
-    SetWindowTextW(hWnd, title?.LPCWSTR)
+    SetWindowTextW(hWnd, title?.wide)
   }
 }

--- a/Sources/SwiftWin32/Views and Controls/TextField.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextField.swift
@@ -39,7 +39,7 @@ private let SwiftTextFieldProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uI
     _ = SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT))
     _ = SetBkMode(hDC, TRANSPARENT)
 
-    _ = DrawTextW(hDC, placeholder.LPCWSTR, -1, &rctClient,
+    _ = DrawTextW(hDC, placeholder.wide, -1, &rctClient,
                   UINT(DT_EDITCONTROL | DT_NOCLIP | DT_NOPREFIX | DT_SINGLELINE | DT_VCENTER))
 
     _ = SelectObject(hDC, hPrevFont)

--- a/Sources/SwiftWin32/Windows and Screens/Screen.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Screen.swift
@@ -56,7 +56,7 @@ public final class Screen {
       }
 
       let _: DeviceContextHandle =
-          ManagedHandle(owning: CreateDCW(szDevice.LPCWSTR, nil, nil, nil))
+          ManagedHandle(owning: CreateDCW(szDevice.wide, nil, nil, nil))
 
       var dsfDeviceScaleFactor: DEVICE_SCALE_FACTOR = SCALE_100_PERCENT
       _ = GetScaleFactorForMonitor(hMonitor, &dsfDeviceScaleFactor)


### PR DESCRIPTION
This is a slight improvement over the original name.  We want the wide
string variant (UTF-16 encoded C string).  Name this accessor `wide` as
Windows traditionally refers to these as "wide strings".