### PR TITLE
build: update the Swift install rule

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(Cassowary SHARED
   ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Symbolics.swift
   ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Term.swift
   ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Variable.swift)
-swift_install(TARGETS Cassowary)
+_install_target(Cassowary)
 
 add_library(SwiftCOM SHARED
   ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/COMBase.swift
@@ -73,7 +73,7 @@ target_link_libraries(SwiftCOM PUBLIC
   Ole32)
 set_target_properties(SwiftCOM PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-swift_install(TARGETS SwiftCOM)
+_install_target(SwiftCOM)
 
 add_subdirectory(CWinRT)
 add_subdirectory(SwiftWin32)

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -168,4 +168,4 @@ set_target_properties(SwiftWin32 PROPERTIES
   INTERFACE_LINK_DIRECTORIES $<TARGET_LINKER_FILE_DIR:SwiftWin32>)
 
 
-swift_install(TARGETS SwiftWin32)
+_install_target(SwiftWin32)

--- a/Sources/SwiftWin32UI/CMakeLists.txt
+++ b/Sources/SwiftWin32UI/CMakeLists.txt
@@ -15,4 +15,4 @@ set_target_properties(SwiftWin32UI PROPERTIES
   INTERFACE_LINK_DIRECTORIES $<TARGET_LINKER_FILE_DIR:SwiftWin32UI>)
 
 
-swift_install(TARGETS SwiftWin32UI)
+_install_target(SwiftWin32UI)

--- a/cmake/Modules/SwiftSupport.cmake
+++ b/cmake/Modules/SwiftSupport.cmake
@@ -1,14 +1,11 @@
-
-include(CMakeParseArguments)
-
 # Returns the architecture name in a variable
 #
 # Usage:
-#   swift_get_host_arch(result_var_name)
+#   get_swift_host_arch(result_var_name)
 #
 # Sets ${result_var_name} with the converted architecture name derived from
 # CMAKE_SYSTEM_PROCESSOR.
-function(swift_get_host_arch result_var_name)
+function(get_swift_host_arch result_var_name)
   if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     set("${result_var_name}" "x86_64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
@@ -55,59 +52,34 @@ function(get_swift_host_os result_var_name)
   endif()
 endfunction()
 
-function(swift_install)
-  set(options)
-  set(single_parameter_options EXPORT)
-  set(multiple_parameter_options TARGETS)
-
-  cmake_parse_arguments(SI
-    "${options}"
-    "${single_parameter_options}"
-    "${multiple_parameter_options}"
-    ${ARGN})
-
-  list(LENGTH ${SI_TARGETS} si_num_targets)
-  if(si_num_targets GREATER 1)
-    message(SEND_ERROR "swift_install only supports a single target at a time")
-  endif()
-
+function(_install_target module)
   get_swift_host_os(swift_os)
-  get_target_property(type ${SI_TARGETS} TYPE)
+  get_target_property(type ${module} TYPE)
 
   if(type STREQUAL STATIC_LIBRARY)
-    set(swift_dir swift_static)
+    set(swift swift_static)
   else()
-    set(swift_dir swift)
+    set(swift swift)
   endif()
 
-  install(TARGETS ${SI_TARGETS}
-    EXPORT ${SI_EXPORT}
-    ARCHIVE DESTINATION lib/${swift_dir}/${swift_os}
-    LIBRARY DESTINATION lib/${swift_dir}/${swift_os}
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
     RUNTIME DESTINATION bin)
   if(type STREQUAL EXECUTABLE)
     return()
   endif()
 
-  swift_get_host_arch(swift_arch)
-  get_target_property(module_name ${SI_TARGETS} Swift_MODULE_NAME)
+  get_swift_host_arch(swift_arch)
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
-    set(module_name ${SI_TARGETS})
+    set(module_name ${module})
   endif()
 
-  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    install(FILES
-      $<TARGET_PROPERTY:${SI_TARGETS},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-      DESTINATION lib/${swift_dir}/${swift_os}/${module_name}.swiftmodule
-      RENAME ${swift_arch}.swiftdoc)
-    install(FILES
-      $<TARGET_PROPERTY:${SI_TARGETS},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-      DESTINATION lib/${swift_dir}/${swift_os}/${module_name}.swiftmodule
-      RENAME ${swift_arch}.swiftmodule)
-  else()
-    install(FILES
-      $<TARGET_PROPERTY:${SI_TARGETS},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-      $<TARGET_PROPERTY:${SI_TARGETS},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-      DESTINATION lib/${swift_dir}/${swift_os}/${swift_arch})
-  endif()
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${swift_arch}.swiftdoc)
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${swift_arch}.swiftmodule)
 endfunction()


### PR DESCRIPTION
The Swift support in CMake has improved to the point where the only
missing piece is the support for `install(TARGET)`.  Emulate the
behaivour with `_install_target`.  Eventually, hopefully, this support
can be replaced with `install(TARGET)`.  Use the 5.4 support for
installing the module in the same manner on all targets.