### PR TITLE
Support: add `Array.remove(object:)`

### DIFF
--- a/Sources/SwiftWin32/Support/Array+Extensions.swift
+++ b/Sources/SwiftWin32/Support/Array+Extensions.swift
@@ -15,5 +15,9 @@ extension Array where Element == UInt16 {
         $1 = $0.count
       }
     }
+
+extension Array where Element: Equatable {
+  mutating func remove(object: Element) {
+    if let index = firstIndex(of: object) { remove(at: index) }
   }
 }

--- a/Sources/SwiftWin32/Support/Array+Extensions.swift
+++ b/Sources/SwiftWin32/Support/Array+Extensions.swift
@@ -15,6 +15,8 @@ extension Array where Element == UInt16 {
         $1 = $0.count
       }
     }
+  }
+}
 
 extension Array where Element: Equatable {
   mutating func remove(object: Element) {


### PR DESCRIPTION
Add a `Array.remove(object:)` function to easily remove an element from
an Array which contains equatable entries.