### PR TITLE
build: add a copyright header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,10 @@
+#[[
+Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+#]]
+
 cmake_minimum_required(VERSION 3.16.0)
 
 project(SwiftWin32

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,3 +1,10 @@
+#[[
+Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+#]]
+
 add_library(Cassowary SHARED
   ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Constraint.swift
   ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Errors.swift

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -1,3 +1,10 @@
+#[[
+Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+#]]
+
 add_library(SwiftWin32 SHARED
   Application/_TriviallyConstructible.swift
   Application/ApplicationMain.swift

--- a/Sources/SwiftWin32UI/CMakeLists.txt
+++ b/Sources/SwiftWin32UI/CMakeLists.txt
@@ -1,3 +1,10 @@
+#[[
+Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+#]]
+
 add_library(SwiftWin32UI SHARED
   EmptyView.swift
   Never+SwiftUI.swift

--- a/cmake/Modules/SwiftSupport.cmake
+++ b/cmake/Modules/SwiftSupport.cmake
@@ -1,3 +1,10 @@
+#[[
+Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+#]]
+
 # Returns the architecture name in a variable
 #
 # Usage:


### PR DESCRIPTION
The build files were missing a copyright header, add the missing header.
Backdate to when the files were initially added.