### PR TITLE
Table View: always reset the state on reload

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -137,10 +137,9 @@ public class TableView: View {
 
   /// Reloads the rows and sections of the table view.
   public func reloadData() {
-    guard let dataSource = self.dataSource else { return }
-
     _ = SendMessageW(self.hWnd, UINT(LB_RESETCONTENT), 0, 0)
 
+    guard let dataSource = self.dataSource else { return }
     for section in 0 ..< dataSource.numberOfSections(in: self) {
       for row in 0 ..< dataSource.tableView(self,
                                             numberOfRowsInSection: section) {


### PR DESCRIPTION
The reloading of the data should clear the state of the tableview even
when the `dataSource` is `nil`.  We would previously continue to display
the stale data as the guard would return too early.