### PR TITLE
Support: add local overloads for type-conversion

### DIFF
--- a/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
@@ -75,6 +75,31 @@ internal let GUID_BATTERY_PERCENTAGE_REMAINING: GUID =
     GUID(Data1: 0xA7AD8041, Data2: 0xB45A, Data3: 0x4CAE,
          Data4: (0x87, 0xA3, 0xEE, 0xCB, 0xB4, 0x68, 0xA9, 0xE1))
 
+@_transparent
+internal var WS_BORDER: DWORD {
+  DWORD(WinSDK.WS_BORDER)
+}
+
+@_transparent
+internal var WS_HSCROLL: DWORD {
+  DWORD(WinSDK.WS_HSCROLL)
+}
+
+@_transparent
+internal var WS_TABSTOP: DWORD {
+  DWORD(WinSDK.WS_TABSTOP)
+}
+
+@_transparent
+internal var WS_VSCROLL: DWORD {
+  DWORD(WinSDK.WS_VSCROLL)
+}
+
+@_transparent
+internal var WS_OVERLAPPEDWINDOW: DWORD {
+  DWORD(WinSDK.WS_OVERLAPPEDWINDOW)
+}
+
 // `GetMessageW` returns `BOOL` but can return `-1` in the case of an error.
 // Explicitly convert the signature to unwrap the `BOOL` to `CInt`.
 func GetMessageW(_ lpMsg: LPMSG?, _ hWnd: HWND?, _ wMsgFilterMin: UINT,

--- a/Sources/SwiftWin32/Views and Controls/Button.swift
+++ b/Sources/SwiftWin32/Views and Controls/Button.swift
@@ -28,7 +28,8 @@ public class Button: Control {
   // `BN_SETFOCUS`, and `BN_UNPUSHED` notification codes only if it has the
   // `BS_NOFITY` style.
   private static let style: WindowStyle =
-      (base: DWORD(WS_TABSTOP | BS_MULTILINE | BS_NOTIFY | BS_PUSHBUTTON), extended: 0)
+      (base: WS_TABSTOP | DWORD(BS_MULTILINE | BS_NOTIFY | BS_PUSHBUTTON),
+       extended: 0)
 
   public init(frame: Rect) {
     super.init(frame: frame, class: Button.class, style: Button.style)

--- a/Sources/SwiftWin32/Views and Controls/DatePicker.swift
+++ b/Sources/SwiftWin32/Views and Controls/DatePicker.swift
@@ -24,7 +24,7 @@ public class DatePicker: Control {
   private static let `class`: WindowClass =
       WindowClass(named: DATETIMEPICK_CLASS)
   private static let style: WindowStyle =
-      (base: WS_POPUP | DWORD(WS_TABSTOP), extended: 0)
+      (base: WS_POPUP | WS_TABSTOP, extended: 0)
 
   /// Configuring the Date Picker Style
 

--- a/Sources/SwiftWin32/Views and Controls/Label.swift
+++ b/Sources/SwiftWin32/Views and Controls/Label.swift
@@ -9,7 +9,7 @@ import WinSDK
 
 public class Label: Control {
   private static let `class`: WindowClass = WindowClass(named: WC_STATIC)
-  private static let style: WindowStyle = (base: DWORD(WS_TABSTOP), extended: 0)
+  private static let style: WindowStyle = (base: WS_TABSTOP, extended: 0)
 
   public override var font: Font! {
     get { return super.font }

--- a/Sources/SwiftWin32/Views and Controls/ProgressView.swift
+++ b/Sources/SwiftWin32/Views and Controls/ProgressView.swift
@@ -9,7 +9,7 @@ import WinSDK
 
 public class ProgressView: Control {
   private static let `class`: WindowClass = WindowClass(named: PROGRESS_CLASS)
-  private static let style: WindowStyle = (base: DWORD(WS_POPUP), extended: 0)
+  private static let style: WindowStyle = (base: WS_POPUP, extended: 0)
 
   public init(frame: Rect) {
     super.init(frame: frame, class: ProgressView.class, style: ProgressView.style)

--- a/Sources/SwiftWin32/Views and Controls/Stepper.swift
+++ b/Sources/SwiftWin32/Views and Controls/Stepper.swift
@@ -68,7 +68,7 @@ private let SwiftStepperProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdS
 public class Stepper: Control {
   private static let `class`: WindowClass = WindowClass(named: UPDOWN_CLASS)
   private static let style: WindowStyle =
-      (base: UInt32(UDS_HORZ) | WS_POPUP | DWORD(WS_TABSTOP), extended: 0)
+      (base: UInt32(UDS_HORZ) | WS_POPUP | WS_TABSTOP, extended: 0)
 
   private static var proxy: StepperProxy = StepperProxy()
 

--- a/Sources/SwiftWin32/Views and Controls/Switch.swift
+++ b/Sources/SwiftWin32/Views and Controls/Switch.swift
@@ -24,7 +24,7 @@ public class Switch: Control {
   // `BN_SETFOCUS`, and `BN_UNPUSHED` notification codes only if it has the
   // `BS_NOFITY` style.
   private static let style: WindowStyle =
-      (base: DWORD(WS_TABSTOP | BS_AUTOCHECKBOX | BS_NOTIFY), extended: 0)
+      (base: WS_TABSTOP | DWORD(BS_AUTOCHECKBOX | BS_NOTIFY), extended: 0)
 
   // MARK - Setting the Off/On State
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -95,7 +95,7 @@ extension TableView {
 public class TableView: View {
   private static let `class`: WindowClass = WindowClass(named: WC_LISTBOX)
   private static let style: WindowStyle =
-      (base: DWORD(WS_BORDER | WS_HSCROLL) | WS_POPUP | DWORD(WS_TABSTOP | WS_VSCROLL | LBS_NODATA | LBS_OWNERDRAWVARIABLE),
+      (base: WS_BORDER | WS_HSCROLL | WS_POPUP | WS_TABSTOP | WS_VSCROLL | DWORD(LBS_NODATA | LBS_OWNERDRAWVARIABLE),
        extended: 0)
 
   private static let proxy: TableViewProxy = TableViewProxy()

--- a/Sources/SwiftWin32/Views and Controls/TextField.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextField.swift
@@ -66,7 +66,7 @@ case justified
 public class TextField: Control {
   private static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
   private static let style: WindowStyle =
-      (base: DWORD(WS_BORDER) | WS_POPUP | DWORD(WS_TABSTOP | ES_AUTOHSCROLL),
+      (base: WS_BORDER | WS_POPUP | WS_TABSTOP | DWORD(ES_AUTOHSCROLL),
        extended: 0)
 
   public weak var delegate: TextFieldDelegate?

--- a/Sources/SwiftWin32/Views and Controls/TextView.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextView.swift
@@ -12,7 +12,7 @@ import Foundation
 public class TextView: View {
   private static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
   private static let style: WindowStyle =
-      (base: DWORD(WS_BORDER | WS_HSCROLL) | WS_POPUP | DWORD(WS_TABSTOP | WS_VSCROLL | ES_MULTILINE),
+      (base: WS_BORDER | WS_HSCROLL | WS_POPUP | WS_TABSTOP | WS_VSCROLL | DWORD(ES_MULTILINE),
        extended: 0)
 
   public var editable: Bool {

--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -383,7 +383,7 @@ public class View: Responder {
     self.GWL_STYLE &= ~WS_CHILD
     // FIXME(compnerd) can this be avoided somehow?
     if self is TextField || self is TextView || self is TableView {
-      self.GWL_STYLE |= WS_BORDER
+      self.GWL_STYLE |= WinSDK.WS_BORDER
       self.GWL_EXSTYLE &= ~WS_EX_CLIENTEDGE
     }
 
@@ -435,7 +435,7 @@ public class View: Responder {
     view.GWL_STYLE |= WS_CHILD
     // FIXME(compnerd) can this be avoided somehow?
     if view is TextField || view is TextView || view is TableView {
-      view.GWL_STYLE |= WS_BORDER
+      view.GWL_STYLE |= WinSDK.WS_BORDER
       view.GWL_EXSTYLE &= ~WS_EX_CLIENTEDGE
     }
 

--- a/Sources/SwiftWin32/Windows and Screens/Window.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Window.swift
@@ -111,7 +111,7 @@ public class Window: View {
                   hbrBackground: GetSysColorBrush(COLOR_3DFACE),
                   hCursor: LoadCursorW(nil, IDC_ARROW))
   private static let style: WindowStyle =
-      (base: DWORD(WS_OVERLAPPEDWINDOW), extended: 0)
+      (base: WS_OVERLAPPEDWINDOW, extended: 0)
 
   public init(frame: Rect) {
     super.init(frame: frame, class: Window.class, style: Window.style)


### PR DESCRIPTION
The imported values are imported as `Int32` rather than `UInt32` which
makes general usage of the values more difficult.  Provide a local
representation which uses the `UInt32` type.