### PR TITLE
tests: avoid using the test harness with SPM

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  **/
 
+#if !SWIFT_PACKAGE
 import XCTest
 
 @testable
@@ -13,3 +14,4 @@ import AutoLayoutTests
 XCTMain([
   testCase(AutoLayoutTests.allTests),
 ])
+#endif


### PR DESCRIPTION
When building with the Swift Package Manager, we should rely on the test auto-discovery.  This file is only needed for building with CMake, which currently does not support building tests.