### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,7 @@ steps:
     cmakeArgs:
       -B $(Build.BinariesDirectory)/swift-win32
       -D BUILD_SHARED_LIBS=YES
+      -D BUILD_TESTING=NO
       -D CMAKE_BUILD_TYPE=Release
       -D CMAKE_C_COMPILER=cl
       -D CMAKE_CXX_COMPILER=cl


### PR DESCRIPTION
Disable testing by default on the Azure Pipelines for now.  We will need to configure the azure pipeline further for using XCTest with CMake.  This should however, enable us to run tests with the CMake build as well.