### PR TITLE
Menus and Shortcuts: make the `fatalError` informative

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuSystem.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuSystem.swift
@@ -11,12 +11,12 @@ public class MenuSystem {
 
   /// The main menu system.
   public class var main: MenuSystem {
-    fatalError()
+    fatalError("\(#function) not yet implemented")
   }
 
   /// The context menu system.
   public class var context: MenuSystem {
-    fatalError()
+    fatalError("\(#function) not yet implemented")
   }
 
   // MARK - Rebuilding a Menu System


### PR DESCRIPTION
Use the same style for the NYI stub in this file as the rest of the
project.