### PR TITLE
WinSDK: add an overload for `WS_CAPTION`

### DIFF
--- a/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
@@ -82,6 +82,11 @@ internal var WS_BORDER: DWORD {
 }
 
 @_transparent
+internal var WS_CAPTION: DWORD {
+  DWORD(WinSDK.WS_CAPTION)
+}
+
+@_transparent
 internal var WS_HSCROLL: DWORD {
   DWORD(WinSDK.WS_HSCROLL)
 }

--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -379,7 +379,7 @@ public class View: Responder {
     superview.willRemoveSubview(self)
 
     // Update the Window style.
-    self.GWL_STYLE &= ~LONG(bitPattern: WS_POPUP | DWORD(WS_CAPTION))
+    self.GWL_STYLE &= ~LONG(bitPattern: WS_POPUP | WS_CAPTION)
     self.GWL_STYLE &= ~WS_CHILD
     // FIXME(compnerd) can this be avoided somehow?
     if self is TextField || self is TextView || self is TableView {
@@ -431,7 +431,7 @@ public class View: Responder {
     // `WM_UPDATEUISTATE`.
 
     // Update the window style.
-    view.GWL_STYLE &= ~LONG(bitPattern: WS_POPUP | DWORD(WS_CAPTION))
+    view.GWL_STYLE &= ~LONG(bitPattern: WS_POPUP | WS_CAPTION)
     view.GWL_STYLE |= WS_CHILD
     // FIXME(compnerd) can this be avoided somehow?
     if view is TextField || view is TextView || view is TableView {


### PR DESCRIPTION
`WS_CAPTION` falls into the same category as the other window style
values - it is meant to be a DWORD.  In C/C++, the type is implicitly
converted, however, in Swift, it will not be.  Provide a DWORD overload
of the value.  For the cases where we need the value as a `LONG`, we can
explicitly use the `WinSDK.` prefix to retrieve the long typed value.
This cleans up most of the usage of the value.