### PR TITLE
reloadData() deletes cells currently in TableView and replaces them with new ones from TableViewDataSource

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -31,6 +31,7 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
         let rctRect: RECT = lpDrawItem.pointee.rcItem
         _ = SetWindowPos(view.hWnd, nil, rctRect.left, rctRect.top, 0, 0,
                          UINT(SWP_NOSIZE))
+        // TODO(rjpilgrim) figure out why this set to isHidden is needed on second call to reloadData()
         view.isHidden = false
         return DefWindowProcW(view.hWnd, UINT(WM_PAINT), 0, 0)
       }

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -31,6 +31,7 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
         let rctRect: RECT = lpDrawItem.pointee.rcItem
         _ = SetWindowPos(view.hWnd, nil, rctRect.left, rctRect.top, 0, 0,
                          UINT(SWP_NOSIZE))
+        view.isHidden = false
         return DefWindowProcW(view.hWnd, UINT(WM_PAINT), 0, 0)
       }
 
@@ -53,6 +54,16 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
     }
 
     return LRESULT(1)
+
+  case UINT(WM_DELETEITEM):
+    let lpDeleteItem: UnsafeMutablePointer<DELETEITEMSTRUCT> =
+        UnsafeMutablePointer<DELETEITEMSTRUCT>(bitPattern: UInt(lParam))!
+    if let view = unsafeBitCast(lpDeleteItem.pointee.itemData,
+                                  to: AnyObject.self) as? View {
+      view.removeFromSuperview()
+    }
+    return LRESULT(1)
+
   default: break
   }
 


### PR DESCRIPTION
reloadData() in TableView currently does nothing except pad the TableView subviews with the new cells.

I needed to add a handle for WM_DeleteItem to the TableView proxy to handle deleting the old cells. This message is triggered by the LB_RESETCONTENT message at the top of reload data.

Test scenario in UICatalog:

```
@main
final class UICatalog: ApplicationDelegate, SceneDelegate {
...
  var funStrings : [String] = ["Iggy", "David", "Lou"]
  var funEnabled : [Bool] = [false, false, false]

  
  lazy var funToggles : () -> [(Button) -> () -> Void] =
    {
      [unowned self] in
      var myList : [(Button) -> () -> Void] = []
      for i in 0..<funEnabled.count {
        myList.append(
        {
          _ in
        { 
          self.funEnabled[i] = !self.funEnabled[i]
          self.tableview.reloadData()
        }
        }
        )
      }
      return myList
    }
}

extension UICatalog: TableViewDataSource {

  public func tableView(_ tableView: TableView,
                        numberOfRowsInSection section: Int) -> Int {
    return 3
  }

  public func tableView(_ tableView: TableView,
                        cellForRowAt indexPath: IndexPath) -> TableViewCell {
    let cell = TableViewCell(style: .default, reuseIdentifier: nil)
    let button = Button(frame: Rect(x: 0, y: 0, width: 80, height: 32),
                           title: "\(funEnabled[indexPath.row] ? funStrings[indexPath.row] : "Button") \(indexPath.row)")
    button.addTarget(button, action: self.funToggles()[indexPath.row],
                          for: .primaryActionTriggered)

    cell.addSubview(button)
    return cell
  }
}
```
