### PR TITLE
UICatalog: the stepper controls the number of rows of the table

### DIFF
--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -169,13 +169,14 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 
   private func stepperValueDidChange(_ stepper: Stepper) {
     self.stepperLabel.text = String(Int(stepper.value))
+    self.tableview.reloadData()
   }
 }
 
 extension UICatalog: TableViewDataSource {
   public func tableView(_ tableView: TableView,
                         numberOfRowsInSection section: Int) -> Int {
-    return 3
+    return Int(stepper.value)
   }
 
   public func tableView(_ tableView: TableView,

--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -141,6 +141,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     self.slider.maximumValue = 100.0
     self.slider.value = 48.0
 
+    self.stepper.value = 2
     self.stepperLabel.text = String(Int(self.stepper.value))
     self.stepper.addTarget(self, action: UICatalog.stepperValueDidChange(_:),
                            for: .valueChanged)


### PR DESCRIPTION
Fixes: #447 
Requires: #452 