### PR TITLE
Only set isHidden when needed

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -32,8 +32,8 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
         _ = SetWindowPos(view.hWnd, nil, rctRect.left, rctRect.top, 0, 0,
                          UINT(SWP_NOSIZE))
         // Setting isHidden is necessary for TableCells generated after initial call to Window.makeKeyAndVisible()
-        let parenthWnd = GetParent(view.hWnd)
-        if IsWindowVisible(parenthWnd) && !IsWindowVisible(view.hWnd) {
+        let hWndParent = GetParent(view.hWnd)
+        if IsWindowVisible(hWndParent) && !IsWindowVisible(view.hWnd) {
             view.isHidden = false
         }
         return DefWindowProcW(view.hWnd, UINT(WM_PAINT), 0, 0)

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -31,7 +31,7 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
         let rctRect: RECT = lpDrawItem.pointee.rcItem
         _ = SetWindowPos(view.hWnd, nil, rctRect.left, rctRect.top, 0, 0,
                          UINT(SWP_NOSIZE))
-        //setting isHidden is necessary for TableCells generated after initial call to Window.makeKeyAndVisible()
+        // Setting isHidden is necessary for TableCells generated after initial call to Window.makeKeyAndVisible()
         let parenthWnd = GetParent(view.hWnd)
         if IsWindowVisible(parenthWnd) && !IsWindowVisible(view.hWnd) {
             view.isHidden = false

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -31,8 +31,11 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
         let rctRect: RECT = lpDrawItem.pointee.rcItem
         _ = SetWindowPos(view.hWnd, nil, rctRect.left, rctRect.top, 0, 0,
                          UINT(SWP_NOSIZE))
-        // TODO(rjpilgrim) figure out why this set to isHidden is needed on second call to reloadData()
-        view.isHidden = false
+        //setting isHidden is necessary for TableCells generated after initial call to Window.makeKeyAndVisible()
+        let parenthWnd = GetParent(view.hWnd)
+        if IsWindowVisible(parenthWnd) && !IsWindowVisible(view.hWnd) {
+            view.isHidden = false
+        }
         return DefWindowProcW(view.hWnd, UINT(WM_PAINT), 0, 0)
       }
 


### PR DESCRIPTION
I have found the reason the TableCells were hidden after reloadData() was called a second time. For the first call which occurs when the data source is initially assigned to the TableView, a call to window.makeKeyAndVisible() follows. makeKeyAndVisible() will then go through and make the TableView and its populated cells visible. On the second call to reloadData(), the call to makeKeyAndVisible() does not occur, and so it is necessary to manually set the Cells to Visible.