### PR TITLE
TableView: adjust spacing (NFC)

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -59,10 +59,12 @@ private let SwiftTableViewProxyWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lPar
   case UINT(WM_DELETEITEM):
     let lpDeleteItem: UnsafeMutablePointer<DELETEITEMSTRUCT> =
         UnsafeMutablePointer<DELETEITEMSTRUCT>(bitPattern: UInt(lParam))!
+
     if let view = unsafeBitCast(lpDeleteItem.pointee.itemData,
-                                  to: AnyObject.self) as? View {
+                                to: AnyObject.self) as? View {
       view.removeFromSuperview()
     }
+
     return LRESULT(1)
 
   default: break


### PR DESCRIPTION
This just cleans up the style around the `WM_DELETEITEM` to match the
rest of the file.