### PR TITLE
Views and Controls: mark Label and ImageView as not having interactions

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/ImageView.swift
+++ b/Sources/SwiftWin32/Views and Controls/ImageView.swift
@@ -78,6 +78,8 @@ public class ImageView: View {
     self.hBitmap = BitmapHandle(from: self.image?.bitmap, hWnd: self.hWnd)
     _ = SendMessageW(self.hWnd, UINT(STM_SETIMAGE), WPARAM(IMAGE_BITMAP),
                      unsafeBitCast(self.hBitmap?.value, to: LPARAM.self))
+
+    self.isUserInteractionEnabled = false
   }
 
   // MARK - Accessing the Displayed Images

--- a/Sources/SwiftWin32/Views and Controls/Label.swift
+++ b/Sources/SwiftWin32/Views and Controls/Label.swift
@@ -69,6 +69,8 @@ public class Label: Control {
     // Perform the font setting in `defer` which ensures that the property
     // observer is triggered.
     defer { self.font = Font.systemFont(ofSize: Font.systemFontSize) }
+
+    self.isUserInteractionEnabled = false
   }
 
   // MARK -


### PR DESCRIPTION
The default state of these objects is meant to have user interactions
disabled.  This updates the implementation to mark them appropriately.
This will break the current behaviour of the Label which will accept
input.  However, the longer term desire is for tap events to be detected
using TapGestureRecognizer, which when bound, requires the user enable
the user interactions.  This moves us in that direction.