### PR TITLE
TextView: extend the text limit

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/TextView.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextView.swift
@@ -37,6 +37,11 @@ public class TextView: View {
 
     // Remove the `WS_EX_CLIENTEDGE` which gives it a flat appearance
     self.GWL_EXSTYLE &= ~WS_EX_CLIENTEDGE
+
+    // Disable compatibility with the original Rich Edit and use the extended
+    // text limit.
+    _ = SendMessageW(self.hWnd, UINT(EM_EXLIMITTEXT),
+                     WPARAM(0), LPARAM(bitPattern: UInt64(bitPattern: -1)))
   }
 
   public func scrollRangeToVisible(_ range: NSRange) {


### PR DESCRIPTION
Ensure that we enable the extended text limit rather than remain
compatible with the old Rich Text implementation.