### PR TITLE
SwiftUI: rename `Application` to `App`

### DIFF
--- a/Sources/SwiftWin32UI/CMakeLists.txt
+++ b/Sources/SwiftWin32UI/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(SwiftWin32UI SHARED
   View.swift
   ViewBuilder.swift)
 target_sources(SwiftWin32UI PRIVATE
-  Essentials/Application.swift
+  Essentials/App.swift
   Essentials/Scene.swift
   Essentials/WindowGroup.swift)
 target_link_libraries(SwiftWin32UI PUBLIC

--- a/Sources/SwiftWin32UI/Essentials/App.swift
+++ b/Sources/SwiftWin32UI/Essentials/App.swift
@@ -8,8 +8,8 @@
 import SwiftWin32
 
 /// A type that represents the structure and behaviour of an application.
-public protocol Application {
-  // MARK - Implementing an Application
+public protocol App {
+  // MARK - Implementing an App
 
   /// The type of scene representing the content of the application.
   associatedtype Body: Scene
@@ -24,7 +24,7 @@ public protocol Application {
   init()
 }
 
-extension Application {
+extension App {
   /// Initializes and runs the application.
   public static func main() {
     ApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil,


### PR DESCRIPTION
This matches the SwiftUI model more accurately.