### PR TITLE
SwiftUI: add initial definition for Group

### DIFF
--- a/Sources/SwiftWin32UI/CMakeLists.txt
+++ b/Sources/SwiftWin32UI/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(SwiftWin32UI PRIVATE
   Essentials/App.swift
   Essentials/Scene.swift
   Essentials/WindowGroup.swift)
+target_sources(SwiftWin32UI PRIVATE
+  "View Layout and Presentation/Group.swift")
 target_link_libraries(SwiftWin32UI PUBLIC
   SwiftWin32)
 set_target_properties(SwiftWin32UI PROPERTIES

--- a/Sources/SwiftWin32UI/View Layout and Presentation/Group.swift
+++ b/Sources/SwiftWin32UI/View Layout and Presentation/Group.swift
@@ -1,0 +1,39 @@
+/**
+ * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+/// An affordance for grouping view content.
+@frozen
+public struct Group<Content> {
+  public typealias Body = Never
+
+  @usableFromInline
+  internal var content: Content
+}
+
+// MARK - Creating a Group
+
+extension Group where Content: View {
+  /// Available when `Content` conforms to `View`.
+  @inlinable
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+}
+
+extension Group where Content: Scene {
+  /// Available when `Content` conforms to `Scene`.
+  @inlinable
+  public init(@SceneBuilder content: () -> Content) {
+    self.content = content()
+  }
+}
+
+extension Group: CustomStringConvertible {
+  public var description: String {
+    "<Group: \(content)>"
+  }
+}


### PR DESCRIPTION
This adds the Group type and add a couple of associated extensions for
construction via `SceneBuilder`s.