### PR TITLE
UI: `Device.isGeneratingDeviceOrientationNotifications` is RO

### DIFF
--- a/Sources/SwiftWin32/App and Environment/Device.swift
+++ b/Sources/SwiftWin32/App and Environment/Device.swift
@@ -133,7 +133,8 @@ public struct Device {
     }
   }
 
-  public var isGeneratingDeviceOrientationNotifications: Bool = false
+  public private(set) var isGeneratingDeviceOrientationNotifications: Bool =
+      false
 
   public func beginGeneratingDeviceOrientationNotifications() {
     // TODO(compnerd) implement this


### PR DESCRIPTION
This variable is a read-only public property, which is altered using
`beginGeneratingDeviceOrientationNotifications` and
`endGeneratingDeviceOrientationNotifications`.