### PR TITLE
adjust the copyright headers to fix the autogenerated docs

### DIFF
--- a/Examples/Calculator/Calculator.swift
+++ b/Examples/Calculator/Calculator.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import SwiftWin32
 import Foundation

--- a/Examples/HelloWorld/HelloWorld.swift
+++ b/Examples/HelloWorld/HelloWorld.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import SwiftWin32
 

--- a/Examples/UICatalog/UICatalog.swift
+++ b/Examples/UICatalog/UICatalog.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import SwiftWin32
 import Foundation

--- a/Sources/SwiftWin32/Animation and Haptics/View Controller Transitions/ViewControllerTransitionCoordinator.swift
+++ b/Sources/SwiftWin32/Animation and Haptics/View Controller Transitions/ViewControllerTransitionCoordinator.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public protocol ViewControllerTransitionCoordinator: ViewControllerTransitionCoordinatorContext {
   /// Responding to View Controller Transition Progress

--- a/Sources/SwiftWin32/Animation and Haptics/View Controller Transitions/ViewControllerTransitionCoordinatorContext.swift
+++ b/Sources/SwiftWin32/Animation and Haptics/View Controller Transitions/ViewControllerTransitionCoordinatorContext.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.TimeInterval
 

--- a/Sources/SwiftWin32/App and Environment/Application.swift
+++ b/Sources/SwiftWin32/App and Environment/Application.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The centralised point of control and coordination for running applications.
 open class Application: Responder {

--- a/Sources/SwiftWin32/App and Environment/ApplicationDelegate.swift
+++ b/Sources/SwiftWin32/App and Environment/ApplicationDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import class Foundation.NSNotification
 

--- a/Sources/SwiftWin32/App and Environment/Device.swift
+++ b/Sources/SwiftWin32/App and Environment/Device.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import class Foundation.NSNotification

--- a/Sources/SwiftWin32/App and Environment/Scenes/Scene.swift
+++ b/Sources/SwiftWin32/App and Environment/Scenes/Scene.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import class Foundation.NSNotification

--- a/Sources/SwiftWin32/App and Environment/Scenes/SceneConfiguration.swift
+++ b/Sources/SwiftWin32/App and Environment/Scenes/SceneConfiguration.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import func Foundation.NSClassFromString
 

--- a/Sources/SwiftWin32/App and Environment/Scenes/SceneDelegate.swift
+++ b/Sources/SwiftWin32/App and Environment/Scenes/SceneDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/App and Environment/Scenes/SceneSession.swift
+++ b/Sources/SwiftWin32/App and Environment/Scenes/SceneSession.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension SceneSession {
   public struct Role: Equatable, Hashable, RawRepresentable {

--- a/Sources/SwiftWin32/App and Environment/Scenes/WindowScene.swift
+++ b/Sources/SwiftWin32/App and Environment/Scenes/WindowScene.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class WindowScene: Scene {
   public required init(session: SceneSession,

--- a/Sources/SwiftWin32/App and Environment/Scenes/WindowSceneDelegate.swift
+++ b/Sources/SwiftWin32/App and Environment/Scenes/WindowSceneDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Additional methods that you can use to manage application specific tasks
 /// occurring in a scene.

--- a/Sources/SwiftWin32/App and Environment/TraitCollection.swift
+++ b/Sources/SwiftWin32/App and Environment/TraitCollection.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/App and Environment/TraitEnvironment.swift
+++ b/Sources/SwiftWin32/App and Environment/TraitEnvironment.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public protocol TraitEnvironment {
   var traitCollection: TraitCollection { get }

--- a/Sources/SwiftWin32/Appearance Customization/Appearance.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Appearance.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A collection of methods that gives you access to the appearance proxy for a
 /// class.

--- a/Sources/SwiftWin32/Appearance Customization/AppearanceContainer.swift
+++ b/Sources/SwiftWin32/Appearance Customization/AppearanceContainer.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A protocol that a class must adopt to allow appearance customization using
 /// the `Appearance` API.

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/BackgroundConfiguration.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/BackgroundConfiguration.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A configuration that describes a specific background appearance.
 public struct BackgroundConfiguration {

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/CellConfigurationState.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/CellConfigurationState.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A structure that encapsulates a cell's state.
 public struct CellConfigurationState: ConfigurationState {

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationColorTransformer.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationColorTransformer.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A transformer that generates a modified output color from an input color.
 public struct ConfigurationColorTransformer {

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationState.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationState.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The requirements for an object that encapsulate a view's state.
 public protocol ConfigurationState {

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationStateCustomKey.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ConfigurationStateCustomKey.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A key that defines a custom state for a view.
 public struct ConfigurationStateCustomKey: Equatable, Hashable, RawRepresentable {

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ContentConfiguration.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ContentConfiguration.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The requirements for an object that provides the configuration for a content
 /// view.

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ContentView.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ContentView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The requirements for a content view that you create using a configuration.
 public protocol ContentView {

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ListContentConfiguration.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ListContentConfiguration.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import class Foundation.NSAttributedString
 

--- a/Sources/SwiftWin32/Appearance Customization/Configurations/ViewConfigurationState.swift
+++ b/Sources/SwiftWin32/Appearance Customization/Configurations/ViewConfigurationState.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A structure that encapsulates a view's state.
 public struct ViewConfigurationState: ConfigurationState {

--- a/Sources/SwiftWin32/Application/ApplicationMain.swift
+++ b/Sources/SwiftWin32/Application/ApplicationMain.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import SwiftCOM

--- a/Sources/SwiftWin32/Application/Information.swift
+++ b/Sources/SwiftWin32/Application/Information.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension Application {
   internal struct SceneConfiguration {

--- a/Sources/SwiftWin32/Application/LaunchKeyOptions.swift
+++ b/Sources/SwiftWin32/Application/LaunchKeyOptions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension Application {
   /// Keys used to access values in the launch options dictionary passed to your

--- a/Sources/SwiftWin32/Application/_TriviallyConstructible.swift
+++ b/Sources/SwiftWin32/Application/_TriviallyConstructible.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 // TODO(compnerd) determine if there is a way to avoid this conformance.  It is
 // required to initialize the class from `ApplicationMain` which takes class

--- a/Sources/SwiftWin32/AutoLayout/LayoutAnchor.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutAnchor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A factory class for creating layout constraint objects using a fluent API.
 public class LayoutAnchor<AnchorType: AnyObject> {

--- a/Sources/SwiftWin32/AutoLayout/LayoutConstraint+Cassowary.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutConstraint+Cassowary.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import Cassowary
 

--- a/Sources/SwiftWin32/AutoLayout/LayoutConstraint.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutConstraint.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension LayoutConstraint {
   /// The relation between the first attribute and the modified second attribute

--- a/Sources/SwiftWin32/AutoLayout/LayoutDimension.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutDimension.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A factory class for creating size-based layout constraint objects using a
 /// fluent API.

--- a/Sources/SwiftWin32/AutoLayout/LayoutGuide.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutGuide.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class LayoutGuide {
   // MARK - Working with Layout Guides

--- a/Sources/SwiftWin32/AutoLayout/LayoutPriority.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutPriority.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The layout priority is used to indicate to the constraint-based layout
 /// system which constraints are more important, allowing the system to make

--- a/Sources/SwiftWin32/AutoLayout/LayoutSupport.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutSupport.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A set of methods that provide layout support and access to layout anchors.
 public protocol LayoutSupport {

--- a/Sources/SwiftWin32/AutoLayout/LayoutXAxisAnchor.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutXAxisAnchor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A factory class for creating horizontal layout constraint objects using a
 /// fluent API.

--- a/Sources/SwiftWin32/AutoLayout/LayoutYAxisAnchor.swift
+++ b/Sources/SwiftWin32/AutoLayout/LayoutYAxisAnchor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A factory class for creating vertical layout constraint objects using a
 /// fluent API.

--- a/Sources/SwiftWin32/CA/Transform3D.swift
+++ b/Sources/SwiftWin32/CA/Transform3D.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The standard transform matrix.
 public struct Transform3D {

--- a/Sources/SwiftWin32/CG/AffineTransform.swift
+++ b/Sources/SwiftWin32/CG/AffineTransform.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import func ucrt.sin
 import func ucrt.cos

--- a/Sources/SwiftWin32/CG/Point.swift
+++ b/Sources/SwiftWin32/CG/Point.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public struct Point {
   public static let zero: Point = Point(x: 0, y: 0)

--- a/Sources/SwiftWin32/CG/Rect.swift
+++ b/Sources/SwiftWin32/CG/Rect.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public struct Rect {
   public static let zero: Rect = Rect(x: 0, y: 0, width: 0, height: 0)

--- a/Sources/SwiftWin32/CG/Size.swift
+++ b/Sources/SwiftWin32/CG/Size.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public struct Size {
   public static let zero: Size = Size(width: 0, height: 0)

--- a/Sources/SwiftWin32/CG/Vector.swift
+++ b/Sources/SwiftWin32/CG/Vector.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A structure that contains a two-dimensional vector.
 public struct Vector {

--- a/Sources/SwiftWin32/Drag and Drop/SpringLoadedInteractionContext.swift
+++ b/Sources/SwiftWin32/Drag and Drop/SpringLoadedInteractionContext.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The spring-loaded interaction states that determine the style of the
 /// interaction view.

--- a/Sources/SwiftWin32/Drawing/BezierPath.swift
+++ b/Sources/SwiftWin32/Drawing/BezierPath.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class BezierPath {
 }

--- a/Sources/SwiftWin32/Drawing/Color.swift
+++ b/Sources/SwiftWin32/Drawing/Color.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Focus-Based Navigation/FocusAnimationCoordinator.swift
+++ b/Sources/SwiftWin32/Focus-Based Navigation/FocusAnimationCoordinator.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.TimeInterval
 

--- a/Sources/SwiftWin32/Focus-Based Navigation/FocusEnvironment.swift
+++ b/Sources/SwiftWin32/Focus-Based Navigation/FocusEnvironment.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An identifier for a focus-related sound.
 public struct FocusSoundIdentifier: Equatable, Hashable, RawRepresentable {

--- a/Sources/SwiftWin32/Focus-Based Navigation/FocusItem.swift
+++ b/Sources/SwiftWin32/Focus-Based Navigation/FocusItem.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An object that can become focused.
 public protocol FocusItem: FocusEnvironment {

--- a/Sources/SwiftWin32/Focus-Based Navigation/FocusItemContainer.swift
+++ b/Sources/SwiftWin32/Focus-Based Navigation/FocusItemContainer.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The container responsible for providing geometric context to focus items
 /// within a given focus environment.

--- a/Sources/SwiftWin32/Focus-Based Navigation/FocusMovementHint.swift
+++ b/Sources/SwiftWin32/Focus-Based Navigation/FocusMovementHint.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Provides movement hint information for the focused item.
 public class FocusMovementHint {

--- a/Sources/SwiftWin32/Focus-Based Navigation/FocusUpdateContext.swift
+++ b/Sources/SwiftWin32/Focus-Based Navigation/FocusUpdateContext.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import class Foundation.NSNotification
 

--- a/Sources/SwiftWin32/Images and PDF/Image.swift
+++ b/Sources/SwiftWin32/Images and PDF/Image.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import SwiftCOM

--- a/Sources/SwiftWin32/Keyboards and Input/TextInputTraits.swift
+++ b/Sources/SwiftWin32/Keyboards and Input/TextInputTraits.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public protocol TextInputTraits {
   /// Managing the Keyboard Behaviour

--- a/Sources/SwiftWin32/Menus and Shortcuts/Action.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Action.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension Action {
   /// A type that represents an action identifier.

--- a/Sources/SwiftWin32/Menus and Shortcuts/Command.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Command.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Constants that indicate which modifier keys are pressed.
 public struct KeyModifierFlags: OptionSet {

--- a/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuConfiguration.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuConfiguration.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import class Foundation.NSUUID
 import protocol Foundation.NSCopying

--- a/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteraction.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteraction.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension ContextMenuInteraction {
   /// Constants that describe the appearance of the menu.

--- a/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteractionAnimating.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteractionAnimating.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Methods adopted by system-supplied animator objects when interacting with
 /// context menus.

--- a/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteractionCommitAnimating.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteractionCommitAnimating.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Constants that control the interaction commit style.
 public enum ContextMenuInteractionCommitStyle: Int {

--- a/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteractionDelegate.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/ContextMenuInteractionDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The methods for providing the set of actions to perform on your content,
 /// and for customizing the preview of that content.

--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import class Foundation.NSUUID

--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuBuilder.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuBuilder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An interface for adding and removing menus from a menu system.
 public protocol MenuBuilder {

--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuElement.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuElement.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuSystem.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuSystem.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An object representing a main or contextual menu system.
 public class MenuSystem {

--- a/Sources/SwiftWin32/Menus and Shortcuts/PreviewParameters.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/PreviewParameters.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import class Foundation.NSValue
 

--- a/Sources/SwiftWin32/Menus and Shortcuts/PreviewTarget.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/PreviewTarget.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An object that specifies the container view to use for animations.
 public class PreviewTarget {

--- a/Sources/SwiftWin32/Menus and Shortcuts/TargetedPreview.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/TargetedPreview.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class TargetedPreview {
   /// Creting a Targeted Preview Object

--- a/Sources/SwiftWin32/Platform/BatteryMonitor.swift
+++ b/Sources/SwiftWin32/Platform/BatteryMonitor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import class Foundation.NotificationCenter

--- a/Sources/SwiftWin32/Platform/Error.swift
+++ b/Sources/SwiftWin32/Platform/Error.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import ucrt
 import WinSDK

--- a/Sources/SwiftWin32/Platform/OrientationSensor.swift
+++ b/Sources/SwiftWin32/Platform/OrientationSensor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import SwiftCOM

--- a/Sources/SwiftWin32/Platform/PropertyWrappers.swift
+++ b/Sources/SwiftWin32/Platform/PropertyWrappers.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Platform/WindowClass.swift
+++ b/Sources/SwiftWin32/Platform/WindowClass.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Platform/WindowsHandle.swift
+++ b/Sources/SwiftWin32/Platform/WindowsHandle.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 internal protocol HandleValue {
   associatedtype HandleType

--- a/Sources/SwiftWin32/Pointer Interactions/PointerInteraction.swift
+++ b/Sources/SwiftWin32/Pointer Interactions/PointerInteraction.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An interaction that enables support for effects on a view or customizes the
 /// pointer's appearance within a region of an app.

--- a/Sources/SwiftWin32/Pointer Interactions/PointerInteractionAnimating.swift
+++ b/Sources/SwiftWin32/Pointer Interactions/PointerInteractionAnimating.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An interface for modifying an interaction animation in coordination with the
 /// pointer effect animations.

--- a/Sources/SwiftWin32/Pointer Interactions/PointerInteractionDelegate.swift
+++ b/Sources/SwiftWin32/Pointer Interactions/PointerInteractionDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An interface for handling pointer movements within the interaction's view.
 public protocol PointerInteractionDelegate: AnyObject {

--- a/Sources/SwiftWin32/Pointer Interactions/PointerRegion.swift
+++ b/Sources/SwiftWin32/Pointer Interactions/PointerRegion.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class PointerRegion {
   // MARK - Configuring a Region

--- a/Sources/SwiftWin32/Pointer Interactions/PointerRegionRequest.swift
+++ b/Sources/SwiftWin32/Pointer Interactions/PointerRegionRequest.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An object to describe the pointer's location in the interaction's view.
 public class PointerRegionRequest {

--- a/Sources/SwiftWin32/Pointer Interactions/PointerStyle.swift
+++ b/Sources/SwiftWin32/Pointer Interactions/PointerStyle.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension PointerEffect {
   /// An effect that defines how to apply a tint to a view during a pointer

--- a/Sources/SwiftWin32/Support/Array+Extensions.swift
+++ b/Sources/SwiftWin32/Support/Array+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import ucrt
 

--- a/Sources/SwiftWin32/Support/IndexPath+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/IndexPath+UIExtensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.IndexPath
 

--- a/Sources/SwiftWin32/Support/Logging.swift
+++ b/Sources/SwiftWin32/Support/Logging.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 #if WITH_SWIFT_LOG
 import Logging

--- a/Sources/SwiftWin32/Support/Point+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/Point+UIExtensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Support/Rect+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/Rect+UIExtensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Support/Size+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/Size+UIExtensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension Size {
   internal init<Integer: FixedWidthInteger>(width: Integer, height: Integer) {

--- a/Sources/SwiftWin32/Support/String+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/String+UIExtensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension String {
   internal init(from utf16: [UInt16]) {

--- a/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Support/WindowMessage.swift
+++ b/Sources/SwiftWin32/Support/WindowMessage.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2021 Ryan Allan <rjallan@g.ucla.edu>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2021 Ryan Allan <rjallan@g.ucla.edu>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Support/WindowsHandle+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/WindowsHandle+UIExtensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Text Display and Fonts/Font.swift
+++ b/Sources/SwiftWin32/Text Display and Fonts/Font.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Text Display and Fonts/FontDescriptor.swift
+++ b/Sources/SwiftWin32/Text Display and Fonts/FontDescriptor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A collection of attributes that describes a font.
 public class FontDescriptor {

--- a/Sources/SwiftWin32/Text Display and Fonts/FontMetrics.swift
+++ b/Sources/SwiftWin32/Text Display and Fonts/FontMetrics.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class FontMetrics {
   /// Creating a Font Metrics Object

--- a/Sources/SwiftWin32/Text Storage/ParagraphStyle.swift
+++ b/Sources/SwiftWin32/Text Storage/ParagraphStyle.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Constants that specify what happens when a line is too long for its
 /// container.

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.TimeInterval
 

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/GestureRecognizer.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/GestureRecognizer.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 // Class constrain the callable to ensure that the value is heap allocated,
 // permitting us to perform pointer equality for the callback to serve as

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/GestureRecognizerDelegate.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/GestureRecognizerDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A set of methods implemented by the delegate of a gesture recognizer to
 /// fine-tune an application’s gesture-recognition behavior.

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Responder.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Responder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 open class Responder {
   // MARK - Managing the Responder Chain

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Touch.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Touch.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.TimeInterval
 

--- a/Sources/SwiftWin32/UI/AnimationCurve.swift
+++ b/Sources/SwiftWin32/UI/AnimationCurve.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public enum AnimationCurve: Int {
 case easeInOut

--- a/Sources/SwiftWin32/UI/ContentSizeCategoryAdjusting.swift
+++ b/Sources/SwiftWin32/UI/ContentSizeCategoryAdjusting.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A collection of methods that gives controls an easy way to adopt automatic
 /// adjustment to content category changes.

--- a/Sources/SwiftWin32/UI/ContentSizeCategoryImageAdjusting.swift
+++ b/Sources/SwiftWin32/UI/ContentSizeCategoryImageAdjusting.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Methods to determine when to adjust images for different content size
 /// categories.

--- a/Sources/SwiftWin32/UI/Interaction.swift
+++ b/Sources/SwiftWin32/UI/Interaction.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The protocol that an interaction implements to access the view that owns it.
 public protocol Interaction: AnyObject {

--- a/Sources/SwiftWin32/UI/SceneSizeRestrictions.swift
+++ b/Sources/SwiftWin32/UI/SceneSizeRestrictions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class SceneSizeRestrictions {
   /// Setting the Size Restrictions

--- a/Sources/SwiftWin32/View Controllers/ContentContainer.swift
+++ b/Sources/SwiftWin32/View Controllers/ContentContainer.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A set of methods for adapting the contents of your view controllers to size
 /// and trait changes.

--- a/Sources/SwiftWin32/View Controllers/ViewController.swift
+++ b/Sources/SwiftWin32/View Controllers/ViewController.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import class Foundation.NSNotification

--- a/Sources/SwiftWin32/Views and Controls/Axis.swift
+++ b/Sources/SwiftWin32/Views and Controls/Axis.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Defines a structure that specifies the layout axes.
 public struct Axis: OptionSet {

--- a/Sources/SwiftWin32/Views and Controls/Button.swift
+++ b/Sources/SwiftWin32/Views and Controls/Button.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Control.swift
+++ b/Sources/SwiftWin32/Views and Controls/Control.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 private protocol ControlEventCallable {
   func callAsFunction(sender: Control, event: Control.Event)

--- a/Sources/SwiftWin32/Views and Controls/DatePicker.swift
+++ b/Sources/SwiftWin32/Views and Controls/DatePicker.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/DirectionalEdgeInsets.swift
+++ b/Sources/SwiftWin32/Views and Controls/DirectionalEdgeInsets.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Edge insets that take language direction into account.
 public struct DirectionalEdgeInsets {

--- a/Sources/SwiftWin32/Views and Controls/DirectionalRectEdge.swift
+++ b/Sources/SwiftWin32/Views and Controls/DirectionalRectEdge.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// Constants that specify an edge or a set of edges, taking the user interface
 /// layout direction into account.

--- a/Sources/SwiftWin32/Views and Controls/EdgeInsets.swift
+++ b/Sources/SwiftWin32/Views and Controls/EdgeInsets.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public class EdgeInsets {
   public static let zero: EdgeInsets = EdgeInsets()

--- a/Sources/SwiftWin32/Views and Controls/ImageView.swift
+++ b/Sources/SwiftWin32/Views and Controls/ImageView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import SwiftCOM

--- a/Sources/SwiftWin32/Views and Controls/Label.swift
+++ b/Sources/SwiftWin32/Views and Controls/Label.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/ProgressView.swift
+++ b/Sources/SwiftWin32/Views and Controls/ProgressView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Slider.swift
+++ b/Sources/SwiftWin32/Views and Controls/Slider.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Stepper.swift
+++ b/Sources/SwiftWin32/Views and Controls/Stepper.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Switch.swift
+++ b/Sources/SwiftWin32/Views and Controls/Switch.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/ContextualAction.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/ContextualAction.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/SwipeActionsConfiguration.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/SwipeActionsConfiguration.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// The set of actions to perform when swiping on rows of a table.
 public class SwipeActionsConfiguration {

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import struct Foundation.IndexPath

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewCell.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewCell.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewDataSource.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewDataSource.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.IndexPath
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewDelegate.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewDelegate.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.IndexPath
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewFocusUpdateContext.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewFocusUpdateContext.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import struct Foundation.IndexPath
 

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewHeaderFooterView.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewHeaderFooterView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
  import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/TextField.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextField.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/TextView.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import Foundation

--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Views and Controls/VisualEffect.swift
+++ b/Sources/SwiftWin32/Views and Controls/VisualEffect.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An initializer for visual effect views and blur and vibrancy effect objects.
 public class VisualEffect {

--- a/Sources/SwiftWin32/Windows and Screens/AlertAction.swift
+++ b/Sources/SwiftWin32/Windows and Screens/AlertAction.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension AlertAction {
   public enum Style: Int {

--- a/Sources/SwiftWin32/Windows and Screens/AlertController.swift
+++ b/Sources/SwiftWin32/Windows and Screens/AlertController.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension AlertController {
   /// Constants indicating the type of alert to display.

--- a/Sources/SwiftWin32/Windows and Screens/CoordinateSpace.swift
+++ b/Sources/SwiftWin32/Windows and Screens/CoordinateSpace.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A set of methods for converting between different frames of reference on a
 /// screen.

--- a/Sources/SwiftWin32/Windows and Screens/Screen.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Screen.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftWin32/Windows and Screens/Window.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Window.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import class Foundation.NSNotification

--- a/Sources/SwiftWin32UI/EmptyView.swift
+++ b/Sources/SwiftWin32UI/EmptyView.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 @frozen
 public struct EmptyView: View {

--- a/Sources/SwiftWin32UI/Essentials/App.swift
+++ b/Sources/SwiftWin32UI/Essentials/App.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import SwiftWin32
 

--- a/Sources/SwiftWin32UI/Essentials/Scene.swift
+++ b/Sources/SwiftWin32UI/Essentials/Scene.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A part of the application's user interface.
 public protocol Scene {

--- a/Sources/SwiftWin32UI/Essentials/WindowGroup.swift
+++ b/Sources/SwiftWin32UI/Essentials/WindowGroup.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 public struct WindowGroup<Content: View>: Scene {
   public var body: some Scene {

--- a/Sources/SwiftWin32UI/Never+SwiftUI.swift
+++ b/Sources/SwiftWin32UI/Never+SwiftUI.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 extension Never: View {
 }

--- a/Sources/SwiftWin32UI/SceneBuilder.swift
+++ b/Sources/SwiftWin32UI/SceneBuilder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 @resultBuilder
 public struct SceneBuilder {

--- a/Sources/SwiftWin32UI/View Layout and Presentation/Group.swift
+++ b/Sources/SwiftWin32UI/View Layout and Presentation/Group.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// An affordance for grouping view content.
 @frozen

--- a/Sources/SwiftWin32UI/ViewBuilder.swift
+++ b/Sources/SwiftWin32UI/ViewBuilder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 @resultBuilder
 public struct ViewBuilder {

--- a/Sources/SwiftWin32UI/Views and Controls/View.swift
+++ b/Sources/SwiftWin32UI/Views and Controls/View.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 /// A type that represents part of your app’s user interface and provides
 /// modifiers that you use to configure views.

--- a/Tests/main.swift
+++ b/Tests/main.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
- * All rights reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import XCTest
 


### PR DESCRIPTION
When generating docs using swift-doc, the copyright header style would
result in the comment being treated as a doc comment.  This adjusts the
style to accommodate that.  This is in preparation for trying to create
autogenerated documentation for the API surface.