### PR TITLE
Touches, Presses, and Gestures: Add TapGestureRecognizer

### DIFF
--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/TapGestureRecognizer.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/TapGestureRecognizer.swift
@@ -1,0 +1,16 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// A discrete gesture recognizer that interprets single or multiple taps.
+public class TapGestureRecognizer: GestureRecognizer {
+  // MARK - Configuring the Gesture
+
+  /// The bitmask of the buttons the user must press for gesture recognition.
+  public var buttonMaskRequired: Event.ButtonMask = [.primary]
+
+  /// The number of taps necessary for gesture recognition.
+  public var numberOfTapsRequired: Int = 1
+
+  /// The number of fingers that the user must tap for gesture recognition.
+  public var numberOfTouchesRequired: Int = 1
+}


### PR DESCRIPTION
This adds a definition forr `TapGestureRecognizer`.  This type
definition is required to wire up tap gesture recognition support for
`Label`s.