### PR TITLE
Correct some regional markers

### DIFF
--- a/Sources/SwiftWin32/Text Display and Fonts/Font.swift
+++ b/Sources/SwiftWin32/Text Display and Fonts/Font.swift
@@ -302,7 +302,7 @@ public class Font {
                                     nil))
   }
 
-  /// Getting the Available Font Names
+  // MARK - Getting the Available Font Names
 
   /// Returns an array of font family names available on the system.
   public static var familyNames: [String] {
@@ -371,11 +371,11 @@ public class Font {
     return Array<String>(arrFonts)
   }
 
-  /// Getting Font Name Attributes
+  // MARK - Getting Font Name Attributes
 
   // public var familyName: String { }
 
-  /// THe font face name.
+  /// The font face name.
   public var fontName: String {
     var lfFont: LOGFONTW = LOGFONTW()
 
@@ -394,7 +394,7 @@ public class Font {
     }
   }
 
-  /// Getting Font Metrics
+  // MARK - Getting Font Metrics
 
   /// The font's point size, or the effective vertical point size for a font
   /// with a non-standard matrix.
@@ -485,7 +485,7 @@ public class Font {
   /// The height, in points, of text lines.
   // public var lineHeight: Double { }
 
-  /// Getting System Font Information
+  // MARK - Getting System Font Information
 
   /// The standard font size, in points, for labels.
   public static var labelFontSize: Double { 17.0 }

--- a/Sources/SwiftWin32/Views and Controls/Table Views/TableViewDataSource.swift
+++ b/Sources/SwiftWin32/Views and Controls/Table Views/TableViewDataSource.swift
@@ -4,7 +4,7 @@
 import struct Foundation.IndexPath
 
 public protocol TableViewDataSource: AnyObject {
-  /// Providng the Number of Rows and Sections
+  // MARK - Providng the Number of Rows and Sections
 
   /// Informs the data source to return the number of rows in a given section of
   /// a table view.
@@ -14,7 +14,7 @@ public protocol TableViewDataSource: AnyObject {
   /// Asks the data source to return the number of sections in the table view.
   func numberOfSections(in tableView: TableView) -> Int
 
-  /// Providing Cells, Headers, and Footers
+  // MARK - Providing Cells, Headers, and Footers
 
   /// Asks the data source for a cell to insert in a particular location of the
   /// table view.


### PR DESCRIPTION
These comments are not documentation comments but rather region markers.
Correct the comment leader to ensure that they do not get misused as
documentation when using a documentation generator.