### PR TITLE
Add inverted() to AffineTransform

### DIFF
--- a/Sources/SwiftWin32/CG/AffineTransform.swift
+++ b/Sources/SwiftWin32/CG/AffineTransform.swift
@@ -59,6 +59,18 @@ public struct AffineTransform {
                            tx: self.tx * transform.a + self.ty * transform.c + transform.tx,
                            ty: self.tx * transform.b + self.ty * transform.d + transform.ty)
   }
+
+  public func inverted() -> AffineTransform {
+    let determinant = a * d - b * c
+    let (newA, newB, newC, newD) = (d/determinant, -b/determinant,
+                                   -c/determinant,  a/determinant)
+    let (newTX, newTY) = (-newA * tx - newC * ty, -newB * tx - newD * ty)
+    let invertedTransform = 
+      AffineTransform( a: newA,  b: newB,
+                       c: newC,  d: newD,
+                      tx: newTX, ty: newTY)
+    return invertedTransform
+  }
 }
 
 extension AffineTransform: Equatable {

--- a/Sources/SwiftWin32/CG/AffineTransform.swift
+++ b/Sources/SwiftWin32/CG/AffineTransform.swift
@@ -61,15 +61,19 @@ public struct AffineTransform {
   }
 
   public func inverted() -> AffineTransform {
-    let determinant = a * d - b * c
-    let (newA, newB, newC, newD) = (d/determinant, -b/determinant,
-                                   -c/determinant,  a/determinant)
-    let (newTX, newTY) = (-newA * tx - newC * ty, -newB * tx - newD * ty)
-    let invertedTransform = 
-      AffineTransform( a: newA,  b: newB,
-                       c: newC,  d: newD,
-                      tx: newTX, ty: newTY)
-    return invertedTransform
+    let determinant = self.a * self.d - self.b * self.c
+
+    // The matrix is in-invertible if the determinant is 0.
+    if determinant == 0 { return self }
+  
+    let a = self.d / determinant
+    let b = -self.b / determinant
+    let c = -self.c / determinant
+    let d = self.a / determinant
+  
+    return AffineTransform(a: a, b: b, c: c, d: d,
+                           tx: -a * self.tx - c * self.ty,
+                           ty: -b * self.tx - d * self.ty)
   }
 }
 


### PR DESCRIPTION
Per your suggestion, I have decided to split the commit for hitTest() and convert() into different parts. I realized that CGAffineTransform from CoreGraphics includes an inverted function. So it makes sense to add it to AffineTransform as well.