### PR TITLE
CI: use terse output by default

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,7 @@ jobs:
         Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
 
     - name: Build
-      run: swift build -v
+      run: swift build
+
     - name: Run tests
-      run: swift test -v
+      run: swift test


### PR DESCRIPTION
In order to reduce the output spew when building to make issues more obvious, disable the verbose build output.