### PR TITLE
View: rename `AnimationCurve` to `View.AnimationCurve`

### DIFF
--- a/Sources/SwiftWin32/Animation and Haptics/View Controller Transitions/ViewControllerTransitionCoordinatorContext.swift
+++ b/Sources/SwiftWin32/Animation and Haptics/View Controller Transitions/ViewControllerTransitionCoordinatorContext.swift
@@ -116,7 +116,7 @@ public protocol ViewControllerTransitionCoordinatorContext {
   var transitionDuration: TimeInterval { get }
 
   /// Returns the completion curve associated with the transition.
-  var completionCurve: AnimationCurve { get }
+  var completionCurve: View.AnimationCurve { get }
 
   /// Returns the starting velocity to use for any final animations.
   var completionVelocity: Double { get }

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -20,7 +20,6 @@ target_sources(SwiftWin32 PRIVATE
   AutoLayout/LayoutXAxisAnchor.swift
   AutoLayout/LayoutYAxisAnchor.swift)
 target_sources(SwiftWin32 PRIVATE
-  UI/AnimationCurve.swift
   UI/ContentSizeCategoryAdjusting.swift
   UI/ContentSizeCategoryImageAdjusting.swift
   UI/Interaction.swift

--- a/Sources/SwiftWin32/UI/AnimationCurve.swift
+++ b/Sources/SwiftWin32/UI/AnimationCurve.swift
@@ -1,9 +1,0 @@
-// Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
-// SPDX-License-Identifier: BSD-3-Clause
-
-public enum AnimationCurve: Int {
-case easeInOut
-case easeIn
-case easeOut
-case linear
-}

--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -168,6 +168,29 @@ extension View.AutoresizingMask {
   }
 }
 
+extension View {
+  /// Specifies the supported animation curves.
+  public enum AnimationCurve: Int {
+    /// An ease-in ease-out curve causes the animation to begin slowly,
+    /// accelerate through the middle of its duration, and then slow again
+    /// before completing. This is the default curve for most animations.
+    case easeInOut
+
+    /// An ease-in curve causes the animation to begin slowly, and then speed up
+    /// as it progresses.
+    case easeIn
+
+    /// An ease-out curve causes the animation to begin quickly, and then slow
+    /// down as it completes.
+    case easeOut
+
+    /// A linear animation curve causes an animation to occur evenly over its
+    /// duration.
+    case linear
+  }
+}
+
+/// An object that manages the content for a rectangular area on the screen.
 public class View: Responder {
   private static let `class`: WindowClass =
       WindowClass(hInst: GetModuleHandleW(nil), name: "Swift.View",


### PR DESCRIPTION
This migrates the `AnimationCurve` to the right location.  It is meant
to be an enclosed type.  Take the opportunity to add some additional
documentation comments around the area.