### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following known limitations are known:
 
 ```cmd
 swift build --product UICatalog
-copy Examples\UICatalog\UICatalog.exe.manifest .build\x86_64-unknown-windows-msvc\debug\
+mt -nologo -manifest Examples\UICatalog\UICatalog.exe.manifest -outputresource:.build\x86_64-unknwon-windows-msvc\debug\UICatalog.exe
 copy Examples\UICatalog\Info.plist .build\x86_64-unknown-windows-msvc\debug\
-swift run UICatalog
+.build\x86_64-unknown-windows-msvc\debug\UICatalog.exe
 ```


### PR DESCRIPTION
Update SPM instructions to avoid copying the manifest.  Instead, have users actually use the manifest tool to embed the manifest as a resource in the executable.  This currently requires the Windows manifest tool as the LLVM manifest tool does not support the `-outputresource:` option which is required to embed the new resource.