### PR TITLE
build: merge the manifest into the modules with CMake

### DIFF
--- a/Examples/Calculator/CMakeLists.txt
+++ b/Examples/Calculator/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(Calculator
   Calculator.swift)
 add_custom_command(TARGET Calculator POST_BUILD
   COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Calculator.exe.manifest $<TARGET_FILE_DIR:Calculator>
+  mt -nologo -manifest ${CMAKE_CURRENT_SOURCE_DIR}/Calculator.exe.manifest -outputresource:$<TARGET_FILE:Calculator>
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist $<TARGET_FILE_DIR:Calculator>)
 # FIXME(SR-12683) `@main` requires `-parse-as-library`

--- a/Examples/UICatalog/CMakeLists.txt
+++ b/Examples/UICatalog/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(UICatalog
   UICatalog.swift)
 add_custom_command(TARGET UICatalog POST_BUILD
   COMMAND
-    ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/UICatalog.exe.manifest $<TARGET_FILE_DIR:UICatalog>
+    mt -nologo -manifest ${CMAKE_CURRENT_SOURCE_DIR}/UICatalog.exe.manifest -outputresource:$<TARGET_FILE:UICatalog>
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist $<TARGET_FILE_DIR:UICatalog>
   COMMAND


### PR DESCRIPTION
When building with CMake, merge the manifest into the binary via a
resource section.  This avoids an additional file which needs to be
distributed and explains how to perform this step.