### PR TITLE
build: use glob for dependent modules

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -5,79 +5,26 @@ All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 #]]
 
+# NOTE(compnerd) because these modules are meant to be static and pristine,
+# there can be no changes to the sources here.  As such, these modules are safe
+# to glob because they cannot impact the build.
+
+file(GLOB CASSOWARY_SOURCES
+     ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/*.swift)
 add_library(Cassowary SHARED
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Constraint.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Errors.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Expression.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Row.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Solver.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Strength.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Symbol.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Symbolics.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Term.swift
-  ${PROJECT_SOURCE_DIR}/Packages/cassowary/Sources/Cassowary/Variable.swift)
+  ${CASSOWARY_SOURCES})
+set_target_properties(Cassowary PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 _install_target(Cassowary)
 
+file(GLOB_RECURSE COM_SOURCES
+     ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/*.swift
+     ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/**/*.swift)
 add_library(SwiftCOM SHARED
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/COMBase.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Shell.swift)
-target_sources(SwiftCOM PRIVATE
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Extensions/COMTypes+Extensions.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Extensions/String+Extensions.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Extensions/WinSDK+Extensions.swift)
-target_sources(SwiftCOM PRIVATE
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Implementation/Human/IFileOperationProgressSink.swift)
-target_sources(SwiftCOM PRIVATE
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IMalloc.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IStream.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/ITypeComp.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/ITypeLib.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Interfaces/IUnknown.swift)
-target_sources(SwiftCOM PRIVATE
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Support/Error.swift
-  ${PROJECT_SOURCE_DIR}/Packages/SwiftCOM/Sources/SwiftCOM/Support/RawTyped.swift)
+  ${COM_SOURCES})
 target_link_libraries(SwiftCOM PUBLIC
-  Ole32)
+  Ole32
+  PortableDeviceGUIDs)
 set_target_properties(SwiftCOM PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 _install_target(SwiftCOM)


### PR DESCRIPTION
The dependent modules are meant to be pristine and do not impact the
build.  When building with CMake, we do not build the dependencies via
SPM.  Because the dependent projects have removed their CMake based
builds, we just simply re-create the sub-project here.  Because there
are meant to be no changes to these dependencies when building
Swift/Win32, we can simply glob the sources.  This avoids maintaining an
out-of-tree build for the project and manually updating the source list.
Furthermore, this matches the SPM based build more accurately.