### PR TITLE
ViewController: change some of the default values

### DIFF
--- a/Sources/SwiftWin32/View Controllers/ViewController.swift
+++ b/Sources/SwiftWin32/View Controllers/ViewController.swift
@@ -200,7 +200,7 @@ public class ViewController: Responder {
   public private(set) var shouldAutorotate: Bool = true
 
   /// The interface orientations that the view controller supports.
-  public private(set) var supportedInterfaceOrientations: InterfaceOrientationMask = .all
+  public private(set) var supportedInterfaceOrientations: InterfaceOrientationMask = .allButUpsideDown
 
   /// The interface orientation to use when presenting the view controller.
   public private(set) var preferredInterfaceOrientationForPresentation: InterfaceOrientation = .portrait


### PR DESCRIPTION
The supported interface orientations is supposed to be
`allButUpsideDown` by default.  This was identified when looking at
further implementing the view controller management interfaces.