### PR TITLE
View: add the `bounds` property

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -282,6 +282,7 @@ public class View: Responder {
                  UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
 
     self.frame = frame
+    self.bounds = Rect(origin: .zero, size: client.size)
 
     super.init()
 
@@ -347,6 +348,12 @@ public class View: Responder {
                        CInt(client.size.width), CInt(client.size.height),
                        UINT(SWP_NOZORDER | SWP_FRAMECHANGED))
     }
+  }
+
+  /// The bounds rectangle, which describes the view’s location and size in its
+  /// own coordinate system.
+  public var bounds: Rect {
+    didSet { fatalError("\(#function) not yet implemented") }
   }
 
   /// The center point of the view's frame rectangle


### PR DESCRIPTION
The bounds represents the coordinate space of the view.  It is the
region of the view which is actually rendered.  We do not currently
support setting the bounds, which allows for resizing the view around
the center by setting the size.  The origin of the view bounds may also
be altered, which will result in the area outside of the bounds being
clipped.