### PR TITLE
CI: split out lint task

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,30 +1,21 @@
-name: windows
+name: lint
 
 on:
-  pull_request:
-    branches: [ main ]
+  pull_request_target:
 
 jobs:
-  build:
+  lint:
     runs-on: windows-latest
-
-    strategy:
-      matrix:
-        include:
-          - tag: 5.4-RELEASE
-            branch: swift-5.4-release
-          - tag: 5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a
-            branch: swift-5.5-branch
-          - tag: DEVELOPMENT-SNAPSHOT-2021-04-26-a
-            branch: development
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
 
-    - name: Install Swift ${{ matrix.tag }}
+    - name: Install Swift 5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a
       run: |
-        Install-Binary -Url "https://swift.org/builds/${{ matrix.branch }}/windows10/swift-${{ matrix.tag }}/swift-${{ matrix.tag }}-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://swift.org/builds/swift-5.5-branch/windows10/swift-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a/swift-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
     - name: Set Environment Variables
       run: |
         echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -40,8 +31,13 @@ jobs:
         Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
         Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
 
-    - name: Build
-      run: swift build -v
-
-    - name: Run tests
-      run: swift test -v
+    - uses: robinraju/release-downloader@v1
+      with:
+        repository: compnerd/swift-build
+        tag: swift-format-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a
+        fileName: swift-format.exe
+        out-file-path: C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\
+    - uses: wearerequired/lint-action@v1
+      with:
+        swift_format_official: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This splits out the lint action to try the `pull_request_trigger`
trigger in the hopes that this will allow fork PRs to be linted.