### PR TITLE
Rect: add definition of `Rect.offsetBy(dx:dy:)`

### DIFF
--- a/Sources/SwiftWin32/CG/Rect.swift
+++ b/Sources/SwiftWin32/CG/Rect.swift
@@ -27,6 +27,11 @@ public struct Rect {
 
   // MARK - Special Values
 
+  /// The null rectangle, representing an invalid value.
+  public static var null: Rect {
+    Rect(x: .infinity, y: .infinity, width: 0.0, height: 0.0)
+  }
+
   /// The rectangle whose origin and size are both zero.
   public static var zero: Rect {
     Rect(x: 0, y: 0, width: 0, height: 0)
@@ -69,6 +74,21 @@ public struct Rect {
     return Rect(origin: Point(x: xs.min()!, y: ys.min()!),
                 size: Size( width: xs.max()! - xs.min()!,
                             height: ys.max()! - ys.min()!))
+  }
+
+  /// Returns a rectangle with an origin that is offset from that of the source
+  /// rectangle.
+  public func offsetBy(dx: Double, dy: Double) -> Rect {
+    guard !self.isNull else { return self }
+    return Rect(x: self.origin.x + dx, y: self.origin.y + dy,
+                width: self.size.width, height: self.size.height)
+  }
+
+  // MARK - Checking Characteristics
+
+  /// Returns whether the rectangle is equal to the null rectangle.
+  public var isNull: Bool {
+    return self == .null
   }
 }
 

--- a/Tests/CoreGraphicsTests/CoreGraphicsTests.swift
+++ b/Tests/CoreGraphicsTests/CoreGraphicsTests.swift
@@ -81,10 +81,28 @@ final class CoreGraphicsTests: XCTestCase {
     XCTAssertEqual(rect.size.height, 87.18621695814943, accuracy: accuracy)
   }
 
+  func testRectOffsetByNullRect() {
+    XCTAssertTrue(Rect.null.offsetBy(dx: 1.0, dy: 1.0).isNull)
+  }
+
+  func testRectOffsetBy() {
+    let r1: Rect = Rect.zero.offsetBy(dx: 4.0, dy: 4.0)
+    XCTAssertEqual(r1.origin, Point(x: 4.0, y: 4.0))
+    XCTAssertEqual(r1.size, .zero)
+
+    let r2: Rect = Rect(origin: Point(x: 4.0, y: 4.0),
+                        size: Size(width: 4.0, height: 4.0))
+                       .offsetBy(dx: 4.0, dy: 4.0)
+    XCTAssertEqual(r2.origin, Point(x: 8.0, y: 8.0))
+    XCTAssertEqual(r2.size, Size(width: 4.0, height: 4.0))
+  }
+
   static var allTests = [
     ("testAffineTransformIdentity", testAffineTransformIdentity),
     ("testAffineTransformIdentityIsIdentity", testAffineTransformIdentityIsIdentity),
     ("testRectComputedProperties", testRectComputedProperties),
     ("testRectApplyAffineTransform", testRectApplyAffineTransform),
+    ("testRectOffsetByNullRect", testRectOffsetByNullRect),
+    ("testRectOffsetBy", testRectOffsetBy),
   ]
 }


### PR DESCRIPTION
This adds the implementation for `Rect.offsetBy(dx:dy:)` and supporting
functions.