### PR TITLE
Rect: correct the definition of `Rect.null`

### DIFF
--- a/Sources/SwiftWin32/CG/Rect.swift
+++ b/Sources/SwiftWin32/CG/Rect.swift
@@ -29,7 +29,8 @@ public struct Rect {
 
   /// The null rectangle, representing an invalid value.
   public static var null: Rect {
-    Rect(x: .infinity, y: .infinity, width: 0.0, height: 0.0)
+    Rect(x: .greatestFiniteMagnitude, y: .greatestFiniteMagnitude,
+         width: 0.0, height: 0.0)
   }
 
   /// The rectangle whose origin and size are both zero.


### PR DESCRIPTION
The null rectangle is defined as `{DBL_MAX, DBL_MAX, 0, 0}`.  The
implementation was incorrectly implemented as
`{INFINITY, INFINITY, 0, 0}`.