### PR TITLE
CoreGraphics: add support for intersection

### DIFF
--- a/Sources/SwiftWin32/CG/Rect.swift
+++ b/Sources/SwiftWin32/CG/Rect.swift
@@ -173,8 +173,25 @@ public struct Rect {
                 height: standardized.size.height)
   }
 
+  /// Returns the intersection of two rectangles.
+  public func intersection(_ rect: Rect) -> Rect {
+    guard !self.isNull, !rect.isNull else { return .null }
+    let lhs: Rect = self.standardized, rhs: Rect = rect.standardized
+
+    let origin: Point = Point(x: max(lhs.minX, rhs.minX),
+                              y: max(lhs.minY, rhs.minY))
+    let size: Size = Size(width: min(lhs.maxX, rhs.maxX) - origin.x,
+                          height: min(lhs.maxY, rhs.maxY) - origin.y)
+    guard size.width > 0, size.height > 0 else { return .null }
+    return Rect(origin: origin, size: size)
+  }
+
   // MARK - Checking Characteristics
 
+  /// Returns whether two rectangles intersect.
+  public func intersects(_ rect: Rect) -> Bool {
+    return !intersection(rect).isEmpty
+  }
 
   /// Returns whether a rectangle has zero width or height, or is a null
   /// rectangle.

--- a/Tests/CoreGraphicsTests/CoreGraphicsTests.swift
+++ b/Tests/CoreGraphicsTests/CoreGraphicsTests.swift
@@ -159,6 +159,50 @@ final class CoreGraphicsTests: XCTestCase {
                    Rect(x: -28.0, y: -28.0, width: 24.0, height: 24.0))
   }
 
+  func testRectIntersection() {
+    let r1: Rect = Rect(x: 0, y: 0, width: 100, height: 100)
+    let r2: Rect = Rect(x: 25, y: 25, width: 50, height: 50)
+    let r3: Rect = Rect(x: 75, y: 75, width: 50, height: 50)
+    let r4: Rect = Rect(x: 125, y: 125, width: 50, height: 50)
+    let r5: Rect = Rect(x: 75, y: 75, width: -50, height: -50)
+
+    // concentric overlap
+    XCTAssertEqual(r1.intersection(r2),
+                   Rect(x: 25, y: 25, width: 50, height: 50))
+
+    // communitivity
+    XCTAssertEqual(r1.intersection(r2), r2.intersection(r1))
+
+    // partial overlap
+    XCTAssertEqual(r1.intersection(r3),
+                   Rect(x: 75, y: 75, width: 25, height: 25))
+
+    // no overlap
+    XCTAssertTrue(r1.intersection(r4).isNull)
+
+    // non-standard
+    XCTAssertEqual(r5.intersection(r1),
+                   Rect(x: 25, y: 25, width: 50, height: 50))
+    XCTAssertEqual(r1.intersection(r5),
+                   Rect(x: 25, y: 25, width: 50, height: 50))
+  }
+
+  func testRectIntersects() {
+    let r1: Rect = Rect(x: 0, y: 0, width: 100, height: 100)
+    let r2: Rect = Rect(x: 25, y: 25, width: 50, height: 50)
+    let r3: Rect = Rect(x: 75, y: 75, width: 50, height: 50)
+    let r4: Rect = Rect(x: 125, y: 125, width: 50, height: 50)
+
+    XCTAssertTrue(r1.intersects(r2))
+    XCTAssertTrue(r2.intersects(r1))
+
+    XCTAssertTrue(r1.intersects(r3))
+    XCTAssertTrue(r3.intersects(r1))
+
+    XCTAssertFalse(r1.intersects(r4))
+    XCTAssertFalse(r4.intersects(r1))
+  }
+
   static var allTests = [
     ("testAffineTransformIdentity", testAffineTransformIdentity),
     ("testAffineTransformIdentityIsIdentity", testAffineTransformIdentityIsIdentity),
@@ -170,5 +214,7 @@ final class CoreGraphicsTests: XCTestCase {
     ("testRectStandardizing", testRectStandardizing),
     ("testRectIntegral", testRectIntegral),
     ("testRectInsetBy", testRectInsetBy),
+    ("testRectIntersection", testRectIntersection),
+    ("testRectIntersects", testRectIntersects),
   ]
 }


### PR DESCRIPTION
This adds the `intersection` and `intersects` methods to `Rect`.