### PR TITLE
Add an instruction for running unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,3 @@ copy Examples\UICatalog\Info.plist .build\x86_64-unknown-windows-msvc\debug\
 In order to run unit tests of Swift/Win32 you need to:
 1. Open `x64 Native Tools Command Prompt for VS 2019`.
 2. Run `swift test -Xswiftc -DENABLE_TESTING`.
-
-### Required software for running tests
-
-| Component | Visual Studio ID |
-| --- | --- |
-| Git for Windows | Microsoft.VisualStudio.Component.Git |

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ copy Examples\UICatalog\Info.plist .build\x86_64-unknown-windows-msvc\debug\
 
 In order to run unit tests of Swift/Win32 you need to:
 1. Open `x64 Native Tools Command Prompt for VS 2019` as administrator.
-2. `cd` to the location of Swift/Win32 on your local computer.
-3. Run `swift test -Xswiftc -DENABLE_TESTING`.
+2. Run `swift test -Xswiftc -DENABLE_TESTING`.
 
 ### Required software for running tests
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ mt -nologo -manifest Examples\UICatalog\UICatalog.exe.manifest -outputresource:.
 copy Examples\UICatalog\Info.plist .build\x86_64-unknown-windows-msvc\debug\
 .build\x86_64-unknown-windows-msvc\debug\UICatalog.exe
 ```
+
+## Running tests
+
+In order to run unit tests of Swift/Win32 you need to:
+1. Open `x64 Native Tools Command Prompt for VS 2019` as administrator.
+2. `cd` to the location of Swift/Win32 on your local computer.
+3. Run `swift test -Xswiftc -DENABLE_TESTING`.
+
+### Required software for running tests
+
+| Component | Visual Studio ID |
+| --- | --- |
+| Git for Windows | Microsoft.VisualStudio.Component.Git |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ copy Examples\UICatalog\Info.plist .build\x86_64-unknown-windows-msvc\debug\
 ## Running tests
 
 In order to run unit tests of Swift/Win32 you need to:
-1. Open `x64 Native Tools Command Prompt for VS 2019` as administrator.
+1. Open `x64 Native Tools Command Prompt for VS 2019`.
 2. Run `swift test -Xswiftc -DENABLE_TESTING`.
 
 ### Required software for running tests


### PR DESCRIPTION
Hi :)

I would like to contribute to Swift/Win32 a little bit  - I want to make some classes `open`.

I first wanted to run the unit tests to make sure I don't break anything, but I struggled to find out how to do it. I'm used to programming on macOS and doing it on Windows is a little bit confusing to me. Anyways, after few hours of digging through Google and this repo I finally found the solution and I thought it would be great if it could be documented in the readme.

I am not sure if those instructions are missing something, but in my case this was enough.