### PR TITLE
Rect: correct the representation of `Rect.null`

### DIFF
--- a/Sources/SwiftWin32/CG/Rect.swift
+++ b/Sources/SwiftWin32/CG/Rect.swift
@@ -65,8 +65,7 @@ public struct Rect {
 
   /// The null rectangle, representing an invalid value.
   public static var null: Rect {
-    Rect(x: .greatestFiniteMagnitude, y: .greatestFiniteMagnitude,
-         width: 0.0, height: 0.0)
+    Rect(x: .infinity, y: .infinity, width: 0.0, height: 0.0)
   }
 
   /// The rectangle whose origin and size are both zero.


### PR DESCRIPTION
Correct a copy-paste error in the definition of `null`.