### PR TITLE
Button: add support for `Action` based handling

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/Action.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Action.swift
@@ -35,6 +35,7 @@ open class Action: MenuElement {
     self.discoverabilityTitle = discoverabilityTitle
     self.attributes = attributes
     self.state = state
+    self.handler = handler
 
     super.init(title: title, image: image)
   }
@@ -70,4 +71,6 @@ open class Action: MenuElement {
 
   /// The object responsible for the action handler.
   open internal(set) var sender: Any?
+
+  internal private(set) var handler: ActionHandler
 }

--- a/Sources/SwiftWin32/Views and Controls/Button.swift
+++ b/Sources/SwiftWin32/Views and Controls/Button.swift
@@ -39,6 +39,17 @@ public class Button: Control {
                           unsafeBitCast(self as AnyObject, to: DWORD_PTR.self))
   }
 
+  /// Creates a new button with the specified frame, registers the primary
+  /// action event, and sets the title and image to the action’s title and
+  /// image.
+  public convenience init(frame: Rect, primaryAction: Action?) {
+    self.init(frame: frame)
+    if let action = primaryAction {
+      self.setTitle(action.title, forState: .normal)
+      self.addAction(action, for: .primaryActionTriggered)
+    }
+  }
+
   // MARK - Configuring the Button Title
 
   /// Sets the title to use for the specified state.

--- a/Sources/SwiftWin32/Views and Controls/Button.swift
+++ b/Sources/SwiftWin32/Views and Controls/Button.swift
@@ -40,7 +40,7 @@ public class Button: Control {
   }
 
   /// Creates a new button with the specified frame, registers the primary
-  /// action event, and sets the title and image to the action’s title and
+  /// action event, and sets the title and image to the action's title and
   /// image.
   public convenience init(frame: Rect, primaryAction: Action?) {
     self.init(frame: frame)

--- a/Tests/UICoreTests/ButtonTests.swift
+++ b/Tests/UICoreTests/ButtonTests.swift
@@ -1,0 +1,28 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+import WinSDK
+@testable import SwiftWin32
+
+final class ButtonTests: XCTestCase {
+  func testConstructWithAction() {
+    let expectation: XCTestExpectation =
+        self.expectation(description: "action is performed")
+
+    let button: Button =
+        Button(frame: .zero, primaryAction: Action { _ in
+          expectation.fulfill()
+        })
+
+    // TODO(compnerd) migrate to UI automation API
+    _ = SendMessageW(button.hWnd, UINT(WM_LBUTTONUP), 0, 0)
+
+    // FIXME(compnerd) what is a good timeout value to use?
+    waitForExpectations(timeout: 1)
+  }
+
+  static var allTests = [
+    ("testConstructWithAction", testConstructWithAction),
+  ]
+}


### PR DESCRIPTION
This allows us to use the newer `Action` based handler to build up
interfaces.  It extends `Control` to invoke an `ActionHandler` rather
than work solely with the target-action pattern.