### PR TITLE
workflows: mock up a code-coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,57 @@
+name: coverage
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.swift'
+      - '!Examples/**/*.swift'
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        include:
+          - tag: DEVELOPMENT-SNAPSHOT-2021-05-17-a
+            branch: development
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seanmiddleditch/gha-setup-vsdevenv@master
+
+    - name: Install Swift ${{ matrix.tag }}
+      run: |
+        Install-Binary -Url "https://swift.org/builds/${{ matrix.branch }}/windows10/swift-${{ matrix.tag }}/swift-${{ matrix.tag }}-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+    - name: Set Environment Variables
+      run: |
+        echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Adjust Paths
+      run: |
+        echo "C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Install Supporting Files
+      run: |
+        Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+        Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+        Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+        Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+    - name: Build
+      run: swift build -v
+
+    - name: Run tests
+      run: swift test -v -Xswiftc -DENABLE_TESTING -enable-code-coverage
+
+    - name: Process Coverage
+      run: |
+        llvm-cov export -format lcov -ignore-filename-regex ".build|Tests|Examples" -instr-profile .build\x86_64-unknown-windows-msvc\debug\codecov\default.profdata .build\x86_64-unknown-windows-msvc\debug\SwiftWin32PackageTests.xctest > $env:Temp\coverage.lcov
+
+    - uses: codecov/codecov-action@v1.5.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: $env:Temp\coverage.lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,12 +1,12 @@
 name: coverage
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '**/*.swift'
-      - '!Examples/**/*.swift'
+  # push:
+  #   branches:
+  #      - main
+  #   paths:
+  #     - '**/*.swift'
+  #     - '!Examples/**/*.swift'
   workflow_dispatch:
 
 jobs:
@@ -40,6 +40,15 @@ jobs:
         Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
         Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
         Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+    - name: WORKAROUND_SR?????, WORKAROUND_SR?????
+      run: |
+        # The correct location
+        New-Item -Path C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\clang\12.0.0\lib\x86_64-unknown-windows-msvc -ItemType Directory
+        Invoke-WebRequest -Uri "https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC81MTM4NS9hcnRpZmFjdE5hbWUvdG9vbGNoYWluLXdpbmRvd3MteDY00/content?format=file&subPath=%2FLibrary%2FDeveloper%2FToolchains%2Funknown-Asserts-development.xctoolchain%2Fusr%2Flib%2Fclang%2F12.0.0%2Flib%2Fx86_64-unknown-windows-msvc%2Fclang_rt.profile.lib" -OutFile C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\clang\12.0.0\lib\x86_64-unknown-windows-msvc\clang_rt.profile.lib
+        # Workaround for the toolchain issue
+        New-Item -Path C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\lib\swift\clang\lib\windows
+        Invoke-WebRequest -Uri "https://artprodeus21.artifacts.visualstudio.com/A8fd008a0-56bc-482c-ba46-67f9425510be/3133d6ab-80a8-4996-ac4f-03df25cd3224/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbXBuZXJkL3Byb2plY3RJZC8zMTMzZDZhYi04MGE4LTQ5OTYtYWM0Zi0wM2RmMjVjZDMyMjQvYnVpbGRJZC81MTM4NS9hcnRpZmFjdE5hbWUvdG9vbGNoYWluLXdpbmRvd3MteDY00/content?format=file&subPath=%2FLibrary%2FDeveloper%2FToolchains%2Funknown-Asserts-development.xctoolchain%2Fusr%2Flib%2Fclang%2F12.0.0%2Flib%2Fx86_64-unknown-windows-msvc%2Fclang_rt.profile.lib" -OutFile C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk\usr\lib\swift\clang\lib\windows\clang_rt.profile-x86_64.lib
 
     - name: Build
       run: swift build -v


### PR DESCRIPTION
This sets up the initial workflow for getting code-coverage information
from the build.  Because we want to track the changes overtime, the
uploaded status should be based on the merged changes, though it would
be nice to get indication on how a change influences the coverage.