### PR TITLE
workflows: move linting to `pull_request`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - uses: seanmiddleditch/gha-setup-vsdevenv@master
 
     - name: Install Swift 5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,11 @@
 name: lint
 
 on:
-  pull_request_target:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.swift'
 
 jobs:
   lint:
@@ -37,10 +41,7 @@ jobs:
         tag: swift-format-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a
         fileName: swift-format.exe
         out-file-path: C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\
-    # - uses: wearerequired/lint-action@v1.9
-    #   with:
-    #     swift_format_official: true
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+
     - uses: compnerd/swift-format-linter-action@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The use of compnerd/swift-format-linter-action avoids the need for the
`pull_request_target` workflow trigger as lint issues are reported via
the GitHub workflow events and does not require write access.