### PR TITLE
VSCode: add workspace configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "cmake.configureOnOpen": false,
+  "files.exclude": {
+    ".git": true,
+    ".build": true,
+    ".*.sw?": true,
+    "**/.DS_Store": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,96 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "problemMatcher": {
+        "owner": "swift",
+        "fileLocation": "autoDetect",
+        "pattern": {
+            "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "message": 5
+        }
+    },
+    "tasks": [
+        {
+            "label": "Build (Debug)",
+            "type": "shell",
+            "command": "swift",
+            "args": [
+                "build",
+                "-c", "debug"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "windows": {
+                "options": {
+                    "shell": {
+                        "executable": "C:\\WINDOWS\\System32\\cmd.exe",
+                        "args": ["/d", "/c"]
+                    }
+                }
+            }
+        },
+        {
+            "label": "Build (Release)",
+            "command": "swift",
+            "args": [
+                "build",
+                "-c", "release"
+            ],
+            "group": "build",
+            "windows": {
+                "options": {
+                    "shell": {
+                        "executable": "C:\\WINDOWS\\System32\\cmd.exe",
+                        "args": ["/d", "/c"]
+                    }
+                }
+            }
+        },
+        {
+            "label": "Test (Debug)",
+            "command": "swift",
+            "args": [
+                "test",
+                "-c", "debug",
+                "-Xswiftc", "-DENABLE_TESTING",
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "windows": {
+                "options": {
+                    "shell": {
+                        "executable": "C:\\WINDOWS\\System32\\cmd.exe",
+                        "args": ["/d", "/c"]
+                    }
+                }
+            }
+        },
+        {
+            "label": "Test (Release)",
+            "command": "swift",
+            "args": [
+                "test",
+                "-c", "release",
+                "-Xswiftc", "-DENABLE_TESTING",
+            ],
+            "group": "test",
+            "windows": {
+                "options": {
+                    "shell": {
+                        "executable": "C:\\WINDOWS\\System32\\cmd.exe",
+                        "args": ["/d", "/c"]
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This adds a workspace configuration to the project to make it easier for
someone to get started.  It adds integration for building with SwiftPM
and ignores the build artifacts and vim swapfiles.