### PR TITLE
Event: correct indentation for enum (NFC)

### DIFF
--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
@@ -6,26 +6,31 @@ import struct Foundation.TimeInterval
 extension Event {
   /// Specifies the general type of event.
   public enum EventType: Int {
-  /// The event is related to touches on the screen.
-  case touches
-  /// The event is related to motion of the device.
-  case motion
-  /// The event is a remote-control event.
-  case remoteControl
-  /// The event is related to the press of a physical button.
-  case presses
+    /// The event is related to touches on the screen.
+    case touches
+
+    /// The event is related to motion of the device.
+    case motion
+
+    /// The event is a remote-control event.
+    case remoteControl
+
+    /// The event is related to the press of a physical button.
+    case presses
   }
 }
 
 extension Event {
   /// Specifies the subtype of the event in relation to its general type.
   public enum EventSubtype: Int {
-  /// The event has no subtype.
-  case none
-  /// The event is related to the user shaking the device.
-  case motionShake
-  /// A remote-control event for playing audio or video.
-  case remoteControlPlay
+    /// The event has no subtype.
+    case none
+
+    /// The event is related to the user shaking the device.
+    case motionShake
+
+    /// A remote-control event for playing audio or video.
+    case remoteControlPlay
   }
 }
 


### PR DESCRIPTION
Adjust indentation for Event enumerations to reflect the Swift style.