### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,6 @@ let SwiftWin32 = Package(
       ],
       swiftSettings: [
         .define("WITH_SWIFT_LOG"),
-        .unsafeFlags(["-Xfrontend", "-validate-tbd-against-ir=none"]),
       ],
       linkerSettings: [
         .linkedLibrary("User32"),


### PR DESCRIPTION
Remove obsoleted workaround which is no longer needed.

The TBD verification step would previously object to exported symbols not matching.  This does not seem to be necessary any longer.