### PR TITLE
build: rely more on autolinking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,10 +32,6 @@ let SwiftWin32 = Package(
       ],
       swiftSettings: [
         .define("WITH_SWIFT_LOG"),
-      ],
-      linkerSettings: [
-        .linkedLibrary("User32"),
-        .linkedLibrary("ComCtl32"),
       ]
     ),
     .target(

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -154,9 +154,6 @@ target_sources(SwiftWin32 PRIVATE
 target_sources(SwiftWin32 PRIVATE
   Support/WindowMessage.swift)
 target_link_libraries(SwiftWin32 PUBLIC
-  ComCtl32
-  User32)
-target_link_libraries(SwiftWin32 PUBLIC
   SwiftCOM)
 target_link_libraries(SwiftWin32 PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>


### PR DESCRIPTION
The manifest definitions have evolved further and should hopefully cover
the necessary autolinking.  This allows the modulemaps to take over and
remove the explicit handling for the linked dependencies.