### PR TITLE
Event: fix an invalid comment leader (NFC)

### DIFF
--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
@@ -66,7 +66,7 @@ extension Event {
 }
 
 public class Event {
-  /// Getting Event Attributes
+  // MARK - Getting Event Attributes
 
   /// The time when the event occurred.
   public var timestamp: TimeInterval


### PR DESCRIPTION
Repair the region specifier for `Event` to ensure that it does not get
mistaken for documentation.