### PR TITLE
UIExtensions: add `UserData` helper function

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -85,6 +85,10 @@ let SwiftWin32 = Package(
         ]),
       ]
     ),
+    .target(
+      name: "TestUtilities",
+      path: "Tests/Utilities"
+    ),
     .testTarget(
       name: "AutoLayoutTests",
       dependencies: ["SwiftWin32"]
@@ -95,7 +99,7 @@ let SwiftWin32 = Package(
     ),
     .testTarget(
       name: "UICoreTests",
-      dependencies: ["SwiftWin32"]
+      dependencies: ["SwiftWin32", "TestUtilities"]
     )
   ]
 )

--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -150,7 +150,8 @@ target_sources(SwiftWin32 PRIVATE
   Support/Size+UIExtensions.swift
   Support/String+UIExtensions.swift
   Support/WindowsHandle+UIExtensions.swift
-  Support/WinSDK+Extensions.swift)
+  Support/WinSDK+Extensions.swift
+  Support/WinSDK+UIExtensions.swift)
 target_sources(SwiftWin32 PRIVATE
   Support/WindowMessage.swift)
 target_link_libraries(SwiftWin32 PUBLIC

--- a/Sources/SwiftWin32/Support/WinSDK+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+UIExtensions.swift
@@ -1,0 +1,12 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import WinSDK
+
+internal func UserData<Type: AnyObject>(from hWnd: HWND?) -> Type? {
+  guard let hWnd = hWnd else { return nil }
+
+  let lpUserData = GetWindowLongPtrW(hWnd, GWLP_USERDATA)
+  return lpUserData == 0 ? nil
+                         : unsafeBitCast(lpUserData, to: AnyObject.self) as? Type
+}

--- a/Sources/SwiftWin32/Views and Controls/Stepper.swift
+++ b/Sources/SwiftWin32/Views and Controls/Stepper.swift
@@ -19,14 +19,10 @@ import WinSDK
 private let SwiftStepperWindowProc: WNDPROC = { (hWnd, uMsg, wParam, lParam) in
   switch uMsg {
   case UINT(WM_HSCROLL):
-    guard let hSender = HWND(bitPattern: UInt(lParam)) else { break }
-
-    let lpInstance = GetWindowLongPtrW(hSender, GWLP_USERDATA)
-    if lpInstance == 0 { break }
-
-    if let stepper = unsafeBitCast(lpInstance, to: AnyObject.self) as? Stepper {
+    if let stepper = UserData(from: HWND(bitPattern: UInt(lParam))) as Stepper? {
       stepper.sendActions(for: .valueChanged)
     }
+
   default:
     break
   }
@@ -64,10 +60,19 @@ public class Stepper: Control {
 
   // MARK - Configuring the Stepper
 
-  public var isContinuous: Bool { fatalError("not yet implemented") }
-  public var autorepeat: Bool { fatalError("not yet implemented") }
+  /// A boolean value that determines whether to send value changes during user
+  /// interaction or after user interaction ends.
+  public var isContinuous: Bool = true {
+    didSet { fatalError("\(#function) not yet implemented") }
+  }
 
-  /// A Boolean value that determines whether the stepper can wrap its value to
+  /// A boolean value that determines whether to repeatedly change the stepper's
+  /// value as the user presses and holds a stepper button.
+  public var autorepeat: Bool = true {
+    didSet { fatalError("\(#function) not yet implemented") }
+  }
+
+  /// A boolean value that determines whether the stepper can wrap its value to
   /// the minimum or maximum value when incrementing and decrementing the value.
   public var wraps: Bool {
     get { self.GWL_STYLE & UDS_WRAP == UDS_WRAP }
@@ -152,6 +157,8 @@ public class Stepper: Control {
       _ = SendMessageW(self.hWnd, UINT(UDM_SETPOS32), 0, LPARAM(DWORD(newValue)))
     }
   }
+
+  // MARK -
 
   public init(frame: Rect) {
     super.init(frame: frame, class: Stepper.class, style: Stepper.style,

--- a/Tests/UICoreTests/StepperTests.swift
+++ b/Tests/UICoreTests/StepperTests.swift
@@ -1,0 +1,60 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import XCTest
+import WinSDK
+import TestUtilities
+@testable import SwiftWin32
+
+final class StepperTests: XCTestCase {
+  func testValueChangedNotification() {
+    let stepper: Stepper = Stepper(frame: .zero)
+
+    let expectation: XCTestExpectation =
+        self.expectation(description: "value change notification dispatched")
+    let observer: ControlEventObserver =
+        ControlEventObserver(expectation: expectation)
+
+    withExtendedLifetime(observer) {
+      stepper.addTarget(observer, action: ControlEventObserver.observe,
+                        for: .valueChanged)
+
+      // TODO(compnerd) this is a workaround until UIAutomation is properly
+      // wired up.  We bypass the Windows UI subsystem, sending the underlying
+      // `WM_HSCROLL` directly to the proxy.
+      if let hWnd = FindWindowW("Swift.Stepper.Proxy".wide, nil) {
+        _ = SendMessageW(hWnd, DWORD(WM_HSCROLL), WPARAM(0),
+                         LPARAM(UInt(bitPattern: stepper.hWnd)))
+      }
+    }
+
+    // FIXME(compnerd) what is a good timeout value to use?
+    waitForExpectations(timeout: 1)
+  }
+
+  func testValueChangedNotificationFailure() {
+    let stepper: Stepper = Stepper(frame: .zero)
+
+    let expectation: XCTestExpectation =
+        self.expectation(description: "value change notification dispatched")
+    expectation.isInverted = true
+
+    let observer: ControlEventObserver =
+        ControlEventObserver(expectation: expectation)
+
+    withExtendedLifetime(observer) {
+      stepper.addTarget(observer, action: ControlEventObserver.observe,
+                        for: .valueChanged)
+
+      // TODO(compnerd) this is a workaround until UIAutomation is properly
+      // wired up.  We bypass the Windows UI subsystem, sending the underlying
+      // `WM_HSCROLL` directly to the proxy.
+      if let hWnd = FindWindowW("Swift.Stepper.Proxy".wide, nil) {
+        _ = SendMessageW(hWnd, DWORD(WM_HSCROLL), WPARAM(0), LPARAM(0))
+      }
+    }
+
+    // FIXME(compnerd) what is a good timeout value to use?
+    waitForExpectations(timeout: 1)
+  }
+}

--- a/Tests/Utilities/Utilities.swift
+++ b/Tests/Utilities/Utilities.swift
@@ -1,0 +1,16 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+
+public class ControlEventObserver {
+  private var expectation: XCTestExpectation
+
+  public init(expectation: XCTestExpectation) {
+    self.expectation = expectation
+  }
+
+  public func observe() {
+    self.expectation.fulfill()
+  }
+}


### PR DESCRIPTION
Add a helper function to access the user data associated with a HWND and
convert it to a type.  This is generally useful and will be used
subsequently to implement more functionality.