### PR TITLE
Touch: adjust indentation for Swift style (NFC)

### DIFF
--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Touch.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Touch.swift
@@ -6,37 +6,46 @@ import struct Foundation.TimeInterval
 extension Touch {
   /// The type of touch received.
   public enum TouchType: Int {
-  /// A touch resulting from direct contact with the screen.
-  case direct
-  /// A touch that did not result from direct contact with the screen.
-  case indirect
-  /// A touch from a stylus.
-  case pencil
+    /// A touch resulting from direct contact with the screen.
+    case direct
+
+    /// A touch that did not result from direct contact with the screen.
+    case indirect
+
+    /// A touch from a stylus.
+    case pencil
   }
 }
 
 extension Touch {
   /// The phase of a touch event.
   public enum Phase: Int {
-  /// A touch for a given event has pressed down on the screen.
-  case began
-  /// A touch for a given event has moved over the screen.
-  case moved
-  /// A touch for a given event is presseddown on the screen, but hasn't moved
-  /// since the previous event.
-  case stationary
-  /// A touch for a given event has lifted from the screen.
-  case ended
-  /// The system cancelled tracking for a touch, for example, when the user
-  /// moves the device against their face.
-  case cancelled
-  /// A touch for a given event has entered a window on the screen.
-  case regionEntered
-  /// A touch for the given event is within a window on the screen, but has not
-  /// yet pressed down.
-  case regionMoved
-  /// A touch for given event has left a window on the screen.
-  case regionExited
+    /// A touch for a given event has pressed down on the screen.
+    case began
+
+    /// A touch for a given event has moved over the screen.
+    case moved
+
+    /// A touch for a given event is presseddown on the screen, but hasn't moved
+    /// since the previous event.
+    case stationary
+
+    /// A touch for a given event has lifted from the screen.
+    case ended
+
+    /// The system cancelled tracking for a touch, for example, when the user
+    /// moves the device against their face.
+    case cancelled
+
+    /// A touch for a given event has entered a window on the screen.
+    case regionEntered
+
+    /// A touch for the given event is within a window on the screen, but has not
+    /// yet pressed down.
+    case regionMoved
+
+    /// A touch for given event has left a window on the screen.
+    case regionExited
   }
 }
 


### PR DESCRIPTION
Adjust the incorrect indentation for `case` statements in the `enum`.