### PR TITLE
UI: make it more explicit that the property is RW

### DIFF
--- a/Sources/SwiftWin32/View Controllers/ViewController.swift
+++ b/Sources/SwiftWin32/View Controllers/ViewController.swift
@@ -103,7 +103,8 @@ public class ViewController: Responder {
 
   /// The preferred size for the view controller's view.
   public var preferredContentSize: Size {
-    fatalError("not yet implemented")
+    get { fatalError("\(#function) not yet implemented") }
+    set { fatalError("\(#function) not yet implemented") }
   }
 
   // MARK - Responding to View Related Events


### PR DESCRIPTION
Mark the fact that property is meant to be read-write more explicit.