### PR TITLE
Touches, Presses, and Gestures: flesh out `Event`

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -90,6 +90,8 @@ target_sources(SwiftWin32 PRIVATE
   "Text Display and Fonts/FontMetrics.swift")
 target_sources(SwiftWin32 PRIVATE
   "Touches, Presses, and Gestures/Event.swift"
+  "Touches, Presses, and Gestures/GestureRecognizer.swift"
+  "Touches, Presses, and Gestures/GestureRecognizerDelegate.swift"
   "Touches, Presses, and Gestures/Responder.swift"
   "Touches, Presses, and Gestures/Touch.swift")
 target_sources(SwiftWin32 PRIVATE

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Event.swift
@@ -65,13 +65,73 @@ extension Event {
   }
 }
 
-public class Event {
+/// An object that describes a single user interaction with your app.
+open class Event {
+  // MARK - Getting the Touches for an Event
+
+  /// Returns all touches associated with the event.
+  open private(set) var allTouches: Set<Touch>?
+
+  /// Returns the touch objects from the event that belong to the specified
+  /// given view.
+  open func touches(for view: View) -> Set<Touch>? {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  /// Returns the touch objects from the event that belong to the specified
+  /// window.
+  open func touches(for window: Window) -> Set<Touch>? {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  /// Returns all of the touches associated with the specified main touch.
+  open func coalescedTouches(for touch: Touch) -> [Touch]? {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  /// Returns an array of touches that are predicted to occur for the specified
+  /// touch.
+  open func predictedTouches(for touch: Touch) -> [Touch]? {
+    fatalError("\(#function) not yet implemented")
+  }
+
   // MARK - Getting Event Attributes
 
   /// The time when the event occurred.
-  public var timestamp: TimeInterval
+  open private(set) var timestamp: TimeInterval
 
-  internal init(timestamp: TimeInterval) {
+  // MARK - Getting the Event Type
+
+  /// Returns the type of the event.
+  open private(set) var type: Event.EventType
+
+  /// Returns the subtype of the event.
+  open private(set) var subtype: Event.EventSubtype
+
+  // MARK - Getting the Touches for a Gesture Recognizer
+
+  /// Returns the touch objects that are being delivered to the specified
+  /// gesture recognizer.
+  open func touches(for gesture: GestureRecognizer) -> Set<Touch>? {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  ///
+  open private(set) var buttonMask: Event.ButtonMask
+
+  // MARK -
+
+  ///
+  open private(set) var modifierFlags: KeyModifierFlags
+
+  // MARK -
+
+  internal init(type: Event.EventType, subtype: Event.EventSubtype,
+                timestamp: TimeInterval) {
+    self.type = type
+    self.subtype = subtype
     self.timestamp = timestamp
+    self.buttonMask = []
+    self.modifierFlags = []
   }
 }

--- a/Tests/UICoreTests/EventTests.swift
+++ b/Tests/UICoreTests/EventTests.swift
@@ -1,0 +1,18 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+@testable import SwiftWin32
+
+final class EventTests: XCTestCase {
+  func testConstructPressesEvent() {
+    let event: Event = .init(type: .presses, subtype: .none, timestamp: 0)
+    XCTAssertEqual(event.buttonMask, [])
+    XCTAssertEqual(event.modifierFlags, [])
+    XCTAssertEqual(event.timestamp, 0)
+  }
+
+  static var allTests = [
+    ("testConstructPressesEvent", testConstructPressesEvent)
+  ]
+}


### PR DESCRIPTION
This adds missing members to `Event`.  Additionally, extend the
designated initializer to ensure that we can easily subtype it as
appropriate.  Now that the type is well specified, mark it as `open` to
allow it to be derived by `open` types.