### PR TITLE
Touches, Presses, and Gestures: add `PressesEvent`

### DIFF
--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/PressesEvent.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/PressesEvent.swift
@@ -1,0 +1,27 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import struct Foundation.TimeInterval
+
+/// An event that describes the state of a set of physical buttons that are
+/// available to the device, such as those on an associated remote or game
+/// controller.
+open class PressesEvent: Event {
+  // MARK - Reading the Event Button Presses
+
+  /// Returns the state of all physical buttons in the event.
+  open private(set) var allPresses: Set<Press>
+
+  /// Returns the state of all physical buttons in the event that are associated
+  /// with a particular gesture recognizer.
+  open func presses(for guesture: GestureRecognizer) -> Set<Press> {
+    fatalError("\(#function) not yet implemented")
+  }
+
+  // MARK -
+
+  internal init(presses: Set<Press>, timestamp: TimeInterval) {
+    self.allPresses = presses
+    super.init(type: .presses, subtype: .none, timestamp: timestamp)
+  }
+}

--- a/Tests/UICoreTests/PressesEventTests.swift
+++ b/Tests/UICoreTests/PressesEventTests.swift
@@ -1,0 +1,18 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+@testable import SwiftWin32
+
+final class PressesEventTests: XCTestCase {
+  func testConstruct() {
+    let event: PressesEvent = .init(presses: [], timestamp: 0)
+    XCTAssertEqual(event.type, .presses)
+    XCTAssertEqual(event.subtype, .none)
+    XCTAssertEqual(event.timestamp, 0)
+  }
+
+  static var allTests = [
+    ("testConstruct", testConstruct),
+  ]
+}


### PR DESCRIPTION
Add a definition for `PressesEvent` which is needed by `Responder`.