### PR TITLE
Menus and Shortcuts: split out the Win32 menu support

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -140,6 +140,7 @@ target_sources(SwiftWin32 PRIVATE
 target_sources(SwiftWin32 PRIVATE
   Platform/BatteryMonitor.swift
   Platform/Error.swift
+  Platform/Win32+Menu.swift
   Platform/Win32+PropertyWrappers.swift
   Platform/WindowClass.swift
   Platform/WindowsHandle.swift)

--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -1,7 +1,6 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-import WinSDK
 import class Foundation.NSUUID
 
 extension Menu {
@@ -250,8 +249,10 @@ extension Menu.Identifier {
 }
 
 
+// MARK - Options for configuring a menu's appearance.
+
 extension Menu {
-  // MARK - Options for configuring a menu's appearance.
+  /// Options for configuring a menu's appearance.
   public struct Options: OptionSet {
     public typealias RawValue = UInt
 
@@ -295,7 +296,7 @@ public class Menu: MenuElement {
   // MARK - Accessing the Child Elements
 
   /// The contents of the menu.
-  public let children: [MenuElement]
+  public private(set) var children: [MenuElement]
 
   /// Creates a new menu with the same configuration as the current menu, but
   /// with a new set of child elements.
@@ -306,22 +307,8 @@ public class Menu: MenuElement {
   // MARK - Getting the Menu Details
 
   /// The unique identifier for the current menu.
-  public let identifier: Menu.Identifier
+  public private(set) var identifier: Menu.Identifier
 
   /// The configuration options for the current menu.
-  public let options: Menu.Options
-}
-
-internal struct Win32Menu {
-  internal let hMenu: MenuHandle
-
-  private let items: [Win32MenuElement]
-
-  internal init(_ hMenu: MenuHandle, items: [MenuElement]) {
-    self.hMenu = hMenu
-    self.items = items.map { Win32MenuElement($0) }
-    for (index, child) in self.items.enumerated() {
-      InsertMenuItemW(hMenu.value, UINT(index), true, &child.info)
-    }
-  }
+  public private(set) var options: Menu.Options
 }

--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuElement.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuElement.swift
@@ -1,8 +1,6 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-import WinSDK
-
 extension MenuElement {
   /// Attributes that determine the style of the menu element.
   public struct Attributes: OptionSet {
@@ -65,63 +63,5 @@ open class MenuElement {
   public init(title: String, image: Image? = nil) {
     self.title = title
     self.image = image
-  }
-}
-
-internal class Win32MenuElement {
-  private var title: [WCHAR]
-  private let submenu: Win32Menu?
-  private let image: BitmapHandle?
-
-  internal var info: MENUITEMINFOW
-
-  private init(title: String, image: Image?, submenu: Win32Menu?, fType: Int32) {
-    self.title = title.wide
-    self.submenu = submenu
-
-    let imageHandle: BitmapHandle?
-    if let bitmap = image?.bitmap {
-      imageHandle = BitmapHandle(from: bitmap)
-    } else {
-      imageHandle = nil
-    }
-    self.image = imageHandle
-
-    self.info = self.title.withUnsafeMutableBufferPointer {
-      MENUITEMINFOW(cbSize: UINT(MemoryLayout<MENUITEMINFOW>.size),
-                    fMask: UINT(MIIM_FTYPE | MIIM_STATE | MIIM_ID | MIIM_STRING | MIIM_SUBMENU | MIIM_DATA | MIIM_BITMAP),
-                    fType: UINT(fType),
-                    fState: UINT(MFS_ENABLED),
-                    wID: UInt32.random(in: .min ... .max),
-                    hSubMenu: submenu?.hMenu.value,
-                    hbmpChecked: nil,
-                    hbmpUnchecked: nil,
-                    dwItemData: 0,
-                    dwTypeData: $0.baseAddress,
-                    cch: UINT(title.count),
-                    hbmpItem: imageHandle?.value)
-    }
-  }
-
-  internal convenience init(_ element: MenuElement) {
-    if let menu = element as? Menu {
-      self.init(title: element.title,
-                image: element.image,
-                submenu: Win32Menu(MenuHandle(owning: CreatePopupMenu()),
-                                   items: menu.children),
-                fType: MFT_STRING)
-    } else {
-      self.init(title: element.title, image: element.image, submenu: nil, fType: MFT_STRING)
-    }
-  }
-}
-
-extension Win32MenuElement {
-  internal static var separator: Win32MenuElement {
-    Win32MenuElement(title: "", image: nil, submenu: nil, fType: MFT_SEPARATOR)
-  }
-
-  internal var isSeparator: Bool {
-    info.fType == MFT_SEPARATOR
   }
 }

--- a/Sources/SwiftWin32/Platform/Win32+Menu.swift
+++ b/Sources/SwiftWin32/Platform/Win32+Menu.swift
@@ -1,0 +1,76 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import WinSDK
+
+internal struct Win32Menu {
+  internal let hMenu: MenuHandle
+
+  private let items: [Win32MenuElement]
+
+  internal init(_ hMenu: MenuHandle, items: [MenuElement]) {
+    self.hMenu = hMenu
+    self.items = items.map { Win32MenuElement($0) }
+    for (index, child) in self.items.enumerated() {
+      InsertMenuItemW(hMenu.value, UINT(index), true, &child.info)
+    }
+  }
+}
+
+internal class Win32MenuElement {
+  private var title: [WCHAR]
+  private let submenu: Win32Menu?
+  private let image: BitmapHandle?
+
+  internal var info: MENUITEMINFOW
+
+  private init(title: String, image: Image?, submenu: Win32Menu?, fType: Int32) {
+    self.title = title.wide
+    self.submenu = submenu
+
+    let imageHandle: BitmapHandle?
+    if let bitmap = image?.bitmap {
+      imageHandle = BitmapHandle(from: bitmap)
+    } else {
+      imageHandle = nil
+    }
+    self.image = imageHandle
+
+    self.info = self.title.withUnsafeMutableBufferPointer {
+      MENUITEMINFOW(cbSize: UINT(MemoryLayout<MENUITEMINFOW>.size),
+                    fMask: UINT(MIIM_FTYPE | MIIM_STATE | MIIM_ID | MIIM_STRING | MIIM_SUBMENU | MIIM_DATA | MIIM_BITMAP),
+                    fType: UINT(fType),
+                    fState: UINT(MFS_ENABLED),
+                    wID: UInt32.random(in: .min ... .max),
+                    hSubMenu: submenu?.hMenu.value,
+                    hbmpChecked: nil,
+                    hbmpUnchecked: nil,
+                    dwItemData: 0,
+                    dwTypeData: $0.baseAddress,
+                    cch: UINT(title.count),
+                    hbmpItem: imageHandle?.value)
+    }
+  }
+
+  internal convenience init(_ element: MenuElement) {
+    if let menu = element as? Menu {
+      self.init(title: element.title,
+                image: element.image,
+                submenu: Win32Menu(MenuHandle(owning: CreatePopupMenu()),
+                                   items: menu.children),
+                fType: MFT_STRING)
+    } else {
+      self.init(title: element.title, image: element.image, submenu: nil, fType: MFT_STRING)
+    }
+  }
+}
+
+extension Win32MenuElement {
+  internal static var separator: Win32MenuElement {
+    Win32MenuElement(title: "", image: nil, submenu: nil, fType: MFT_SEPARATOR)
+  }
+
+  internal var isSeparator: Bool {
+    info.fType == MFT_SEPARATOR
+  }
+}


### PR DESCRIPTION
This extracts the menu logic out of the various files into a standalone
platform support structure to isolate the logic.