### PR TITLE
Menus and Shortcuts: add `Equatable` and `Hashable` conformances

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -312,3 +312,16 @@ public class Menu: MenuElement {
   /// The configuration options for the current menu.
   public private(set) var options: Menu.Options
 }
+
+extension Menu: Equatable {
+  public static func ==(_ lhs: Menu, _ rhs: Menu) -> Bool {
+    // FIXME(compnerd) is this the correct check for equality?
+    return lhs === rhs
+  }
+}
+extension Menu: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    // FIXME(compnerd) is this the correct hashing?
+    hasher.combine(ObjectIdentifier(self))
+  }
+}

--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Press.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Press.swift
@@ -109,13 +109,14 @@ open class Press {
 
 extension Press: Equatable {
   public static func ==(_ lhs: Press, _ rhs: Press) -> Bool {
-    return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    // FIXME(compnerd) is this the correct check for equality?
+    return lhs === rhs
   }
 }
 
 extension Press: Hashable {
   public func hash(into hasher: inout Hasher) {
-    // FIXME(compnerd) figure out the correct hashing function
+    // FIXME(compnerd) is this the correct hashing?
     hasher.combine(self.type)
     hasher.combine(self.phase)
     hasher.combine(self.force)


### PR DESCRIPTION
Make `Menu` conform to `Equatable` and `Hashable`.  This is required for
`Menu` to be used in an `OrderedSet`.  Technically, the type can inherit
from `NSObject`, which gives it an implicit `Equatable` and `Hashable`
conformance.  Since we do not pervasively use `NSObject`, we must
synthesize the conformance explicitly.

Tweak the comments for `Press`'s conformances so that we can find all of
them with a single pattern.