### PR TITLE
Platform: start implementing a `MenuBuilder` for Win32

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -296,7 +296,7 @@ public class Menu: MenuElement {
   // MARK - Accessing the Child Elements
 
   /// The contents of the menu.
-  public private(set) var children: [MenuElement]
+  public internal(set) var children: [MenuElement]
 
   /// Creates a new menu with the same configuration as the current menu, but
   /// with a new set of child elements.

--- a/Sources/SwiftWin32/Platform/Win32+Menu.swift
+++ b/Sources/SwiftWin32/Platform/Win32+Menu.swift
@@ -3,6 +3,9 @@
 
 import WinSDK
 
+@_implementationOnly
+import OrderedCollections
+
 internal struct Win32Menu {
   internal let hMenu: MenuHandle
 
@@ -72,5 +75,92 @@ extension Win32MenuElement {
 
   internal var isSeparator: Bool {
     info.fType == MFT_SEPARATOR
+  }
+}
+
+internal final class _MenuBuilder: MenuSystem {
+  internal private(set) var hMenu: MenuHandle
+  internal private(set) weak var view: View?
+
+  private var menus: OrderedSet<Menu>
+
+  internal init?(for view: View) {
+    self.hMenu = MenuHandle(owning: CreateMenu())
+    if self.hMenu.value == nil {
+      log.warning("CreateMenu: \(Error(win32: GetLastError()))")
+      return nil
+    }
+    self.view = view
+    self.menus = []
+  }
+}
+
+extension _MenuBuilder: MenuBuilder {
+  public var system: MenuSystem {
+    return self
+  }
+
+  public func menu(for identifier: Menu.Identifier) -> Menu? {
+    self.menus.first { $0.identifier == identifier }
+  }
+
+  public func action(for identifier: Action.Identifier) -> Action? {
+    return nil
+  }
+
+  public func insertChild(_ menu: Menu,
+                          atStartOfMenu identifier: Menu.Identifier) {
+    // FIXME(compnerd) what happens if the element is not found?
+    if let index = self.menus.firstIndex(where: { $0.identifier == identifier }) {
+      let parent = self.menus[index]
+      parent.children.insert(menu, at: parent.children.startIndex)
+    }
+  }
+
+  public func insertChild(_ menu: Menu,
+                          atEndOfMenu identifier: Menu.Identifier) {
+    // FIXME(compnerd) what happens if the element is not found?
+    if let index = self.menus.firstIndex(where: { $0.identifier == identifier }) {
+      let parent = self.menus[index]
+      parent.children.insert(menu, at: parent.children.endIndex)
+    }
+  }
+
+  public func insertSibling(_ menu: Menu,
+                            beforeMenu identifier: Menu.Identifier) {
+    let index: OrderedSet<Menu>.Index =
+      identifier == .root
+          ? self.menus.startIndex
+          : self.menus.firstIndex { $0.identifier == identifier } ?? self.menus.startIndex
+    self.menus.insert(menu, at: index)
+  }
+
+  public func insertSibling(_ menu: Menu,
+                            afterMenu identifier: Menu.Identifier) {
+    let index: OrderedSet<Menu>.Index =
+        identifier == .root
+            ? self.menus.endIndex
+            : self.menus.firstIndex { $0.identifier == identifier } ?? self.menus.endIndex
+    self.menus.insert(menu, at: index)
+  }
+
+  public func replace(menu identifier: Menu.Identifier, with menu: Menu) {
+    // FIXME(compnerd) should we be appending the item if the specified
+    // identifier is not found?
+    if let index = self.menus.firstIndex(where: { $0.identifier == identifier }) {
+      _ = self.menus.remove(at: index)
+      self.menus.insert(menu, at: index)
+    }
+  }
+
+  public func replaceChildren(ofMenu parentIdentifier: Menu.Identifier,
+                              from childrenBlock: ([MenuElement]) -> [MenuElement]) {
+  }
+
+  public func remove(menu identifier: Menu.Identifier) {
+    // FIXME(compnerd) what happens if the element is not found?
+    if let index = self.menus.firstIndex(where: { $0.identifier == identifier }) {
+      _ = self.menus.remove(at: index)
+    }
   }
 }

--- a/Tests/UICoreTests/MenuBuilderTests.swift
+++ b/Tests/UICoreTests/MenuBuilderTests.swift
@@ -1,0 +1,100 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+@testable import SwiftWin32
+
+final class MenuBuilderTests: XCTestCase {
+  func testConstruct() {
+    let view: View = View(frame: .zero)
+
+    let builder: MenuBuilder? = _MenuBuilder(for: view)
+    XCTAssertNotNil(builder)
+  }
+
+  func testInsertSibling() {
+    let view: View = View(frame: .zero)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    builder.insertSibling(Menu(identifier: .application), beforeMenu: .root)
+    XCTAssertNotNil(builder.menu(for: .application))
+
+    builder.insertSibling(Menu(identifier: .edit), afterMenu: .root)
+    XCTAssertNotNil(builder.menu(for: .edit))
+
+    builder.insertSibling(Menu(identifier: .file), beforeMenu: .edit)
+    XCTAssertNotNil(builder.menu(for: .file))
+
+    builder.insertSibling(Menu(identifier: .services), beforeMenu: .quit)
+    XCTAssertNotNil(builder.menu(for: .services))
+
+    builder.insertSibling(Menu(identifier: .help), afterMenu: .quit)
+    XCTAssertNotNil(builder.menu(for: .help))
+  }
+
+  func testInsertChild() {
+    let view: View = View(frame: .zero)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    builder.insertSibling(Menu(identifier: .window), beforeMenu: .view)
+    let window = builder.menu(for: .window)
+    XCTAssertNotNil(window)
+
+    builder.insertChild(Menu(identifier: .bringAllToFront),
+                        atStartOfMenu: .window)
+    builder.insertChild(Menu(identifier: .minimizeAndZoom),
+                        atEndOfMenu: .window)
+
+    XCTAssertEqual(window?.children.count ?? 0, 2)
+    XCTAssertEqual((window?.children[0] as? Menu)?.identifier, .bringAllToFront)
+    XCTAssertEqual((window?.children[1] as? Menu)?.identifier, .minimizeAndZoom)
+
+    builder.insertChild(Menu(identifier: .fullscreen),
+                        atStartOfMenu: .preferences)
+    builder.insertChild(Menu(identifier: .toolbar),
+                        atEndOfMenu: .hide)
+  }
+
+  func testRemove() {
+    let view: View = View(frame: .zero)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    builder.insertSibling(Menu(identifier: .application), beforeMenu: .root)
+    XCTAssertNotNil(builder.menu(for: .application))
+
+    builder.remove(menu: .application)
+    XCTAssertNil(builder.menu(for: .application))
+  }
+
+  func testReplace() {
+    let view: View = View(frame: .zero)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    builder.insertSibling(Menu(identifier: .application), beforeMenu: .root)
+    XCTAssertNotNil(builder.menu(for: .application))
+
+    builder.replace(menu: .application, with: Menu(identifier: .file))
+    XCTAssertNil(builder.menu(for: .application))
+    XCTAssertNotNil(builder.menu(for: .file))
+
+    XCTAssertNil(builder.menu(for: .quit))
+    builder.replace(menu: .quit, with: Menu(identifier: .about))
+    XCTAssertNotNil(builder.menu(for: .file))
+    XCTAssertNil(builder.menu(for: .about))
+  }
+
+  func testBuildMenu() {
+    let view: View = View(frame: .zero)
+    let builder = _MenuBuilder(for: view)
+    XCTAssertNotNil((builder?.system as? _MenuBuilder)?.hMenu.value)
+  }
+
+  public static var allTests = [
+    ("testConstruct", testConstruct),
+    ("testInsertSibling", testInsertSibling),
+    ("testInsertChild", testInsertChild),
+    ("testRemove", testRemove),
+    ("testReplace", testReplace),
+    ("testBuildMenu", testBuildMenu),
+  ]
+}


### PR DESCRIPTION
This is meant to be the internal implementation for a Windows menu
system/builder interface.  When complete, this should be able to subsume
the current implementation of `Win32Menu` and `Win32MenuElement`.  This
implementation instead keeps everything in terms of the raw `Menu` type
for the duration of the builder's lifetime.  When the builder is
complete, we can take the description as provided by the fluent
MenuBuilder API and materialize the menu structure in a single pass.
This will avoid the unnecessary allocation of handles during the
construction.