### PR TITLE
Menus and Shortcuts: tweak hashing

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -264,6 +264,9 @@ extension Menu {
   }
 }
 
+extension Menu.Options: Hashable {
+}
+
 extension Menu.Options {
   /// An option indicating the menu displays inline with its parent menu instead
   /// of displaying as a submenu.
@@ -322,7 +325,7 @@ extension Menu: Equatable {
 extension Menu: Hashable {
   public func hash(into hasher: inout Hasher) {
     // FIXME(compnerd) is this the correct hashing?
-    hasher.combine(self.children)
+    hasher.combine(self.children.count)
     hasher.combine(self.identifier)
     hasher.combine(self.options)
   }

--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -322,6 +322,8 @@ extension Menu: Equatable {
 extension Menu: Hashable {
   public func hash(into hasher: inout Hasher) {
     // FIXME(compnerd) is this the correct hashing?
-    hasher.combine(ObjectIdentifier(self))
+    hasher.combine(self.children)
+    hasher.combine(self.identifier)
+    hasher.combine(self.options)
   }
 }


### PR DESCRIPTION
Include the members in the hashing rather than the object identifier.