### PR TITLE
View and Controls: avoid a deprecation warning (NFC)

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -942,6 +942,6 @@ extension View: Equatable {
 
 extension View: TraitEnvironment {
   public var traitCollection: TraitCollection {
-    return self.window?.screen.traitCollection ?? TraitCollection.current
+    return self.window?.windowScene?.screen.traitCollection ?? TraitCollection.current
   }
 }


### PR DESCRIPTION
Use `window?.windowScene?.scene` rather than `window?.scene` to
determine the traits.