### PR TITLE
Menus and Shortcuts: open `MenuSystem`

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/MenuSystem.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/MenuSystem.swift
@@ -2,28 +2,28 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// An object representing a main or contextual menu system.
-public class MenuSystem {
+open class MenuSystem {
   // MARK - Getting a Menu System
 
   /// The main menu system.
-  public class var main: MenuSystem {
+  open class var main: MenuSystem {
     fatalError("\(#function) not yet implemented")
   }
 
   /// The context menu system.
-  public class var context: MenuSystem {
+  open class var context: MenuSystem {
     fatalError("\(#function) not yet implemented")
   }
 
   // MARK - Rebuilding a Menu System
 
   /// Tells the menu system to rebuild all of its menus.
-  public func setNeedsRebuild() {
+  open func setNeedsRebuild() {
   }
 
   // MARK - Revalidating a Menu System
 
   /// Tells the menu system to validate all of its menus.
-  public func setNeedsRevalidate() {
+  open func setNeedsRevalidate() {
   }
 }


### PR DESCRIPTION
Adjust the definition of `MenuSystem` to convert the class to `open`.