### PR TITLE
Menus and Shortcuts: add overloads for window menu construction

### DIFF
--- a/Sources/SwiftWin32/Touches, Presses, and Gestures/Responder.swift
+++ b/Sources/SwiftWin32/Touches, Presses, and Gestures/Responder.swift
@@ -60,6 +60,18 @@ open class Responder {
   public func touchesEstimatedPropertiesUpdated(_ touches: Set<Touch>) {
   }
 
+  // MARK - Building and Validating Commands
+
+  /// Asks the receiving responder to add and remove items from a menu system.
+  open func buildMenu(with builder: MenuBuilder) {
+    self.next?.buildMenu(with: builder)
+  }
+
+  /// Asks the receiving responder to validate the command.
+  open func validate(_ command: Command) {
+    self.next?.validate(command)
+  }
+
   // MARK - Constants
 
   /// A user info key to retrieve the animation curve that the system uses to


### PR DESCRIPTION
This mimics the UIKit's `UIResponder` API. These overloads will be wired to the `ViewController` to actually display the menus.

By default let's just pass the events to the next responder. The subclasses which need a custom menu will need to override these.
