### PR TITLE
Menus and Shortcuts: correct typo for identifier (NFC)

### DIFF
--- a/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
+++ b/Sources/SwiftWin32/Menus and Shortcuts/Menu.swift
@@ -159,7 +159,7 @@ extension Menu.Identifier {
 
   /// The Transformations menu.
   public static var transformations: Menu.Identifier {
-    Menu.Identifier(rawValue: "org.compnerd.swift-win32.menu.transoformations")
+    Menu.Identifier(rawValue: "org.compnerd.swift-win32.menu.transformations")
   }
 
   /// The Speech menu.


### PR DESCRIPTION
This corrects a typo in the identifier name.  The value is meaningless
in practical terms as the `ObjectIdentifier` is the identifier (that is,
it is used for pointer identity), but it is annoying.