### PR TITLE
Menus and Shortcuts: make `_MenuBuilder` materialize the menus

### DIFF
--- a/Tests/UICoreTests/MenuBuilderTests.swift
+++ b/Tests/UICoreTests/MenuBuilderTests.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import XCTest
+import WinSDK
 @testable import SwiftWin32
 
 final class MenuBuilderTests: XCTestCase {
@@ -85,8 +86,47 @@ final class MenuBuilderTests: XCTestCase {
 
   func testBuildMenu() {
     let view: View = View(frame: .zero)
-    let builder = _MenuBuilder(for: view)
-    XCTAssertNotNil((builder?.system as? _MenuBuilder)?.hMenu.value)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    let hMenu = (builder.system as? _MenuBuilder)?.hMenu
+    XCTAssertNotNil(hMenu?.value)
+    XCTAssertEqual(GetMenuItemCount(hMenu?.value), 0)
+  }
+
+  func testBuildMenuWithChildren() {
+    let view: View = View(frame: .zero)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    let menu = Menu(title: "menu1", children: [Command(title: "item1") { _ in },
+                                               Action(title: "item2") { _ in }])
+    builder.insertSibling(menu, afterMenu: .root)
+    builder.setNeedsRebuild()
+
+    let hRootMenu = (builder.system as? _MenuBuilder)?.hMenu
+    XCTAssertNotNil(hRootMenu?.value)
+    XCTAssertEqual(GetMenuItemCount(hRootMenu?.value), 1)
+
+    let hMenu = GetSubMenu(hRootMenu?.value, 0)
+    XCTAssertNotNil(hMenu)
+    XCTAssertEqual(GetMenuItemCount(hMenu), 2)
+  }
+
+  func testRebuildMenu() {
+    let view: View = View(frame: .zero)
+    guard let builder = _MenuBuilder(for: view) else { return }
+
+    let hMenu1 = (builder.system as? _MenuBuilder)?.hMenu
+
+    let menu = Menu(title: "title", children: [Command(title: "cmd") { _ in }])
+    builder.insertSibling(menu, afterMenu: .root)
+    builder.setNeedsRebuild()
+
+    let hMenu2 = (builder.system as? _MenuBuilder)?.hMenu
+
+    XCTAssert(hMenu1 === hMenu2)
+    XCTAssertNotNil(hMenu1)
+    XCTAssertNotNil(hMenu2)
+    XCTAssertEqual(hMenu1?.value, hMenu2?.value)
   }
 
   public static var allTests = [
@@ -96,5 +136,7 @@ final class MenuBuilderTests: XCTestCase {
     ("testRemove", testRemove),
     ("testReplace", testReplace),
     ("testBuildMenu", testBuildMenu),
+    ("testBuildMenuWithChildren", testBuildMenuWithChildren),
+    ("testRebuildMenu", testRebuildMenu),
   ]
 }


### PR DESCRIPTION
This change teaches `_MenuBuilder` to build the window menus. It handles submenus & icons similarly to `Win32Menu`.