### PR TITLE
View and Controls: remove context menu handling

### DIFF
--- a/Sources/SwiftWin32/Platform/Win32+Menu.swift
+++ b/Sources/SwiftWin32/Platform/Win32+Menu.swift
@@ -6,78 +6,6 @@ import WinSDK
 @_implementationOnly
 import OrderedCollections
 
-internal struct Win32Menu {
-  internal let hMenu: MenuHandle
-
-  private let items: [Win32MenuElement]
-
-  internal init(_ hMenu: MenuHandle, items: [MenuElement]) {
-    self.hMenu = hMenu
-    self.items = items.map { Win32MenuElement($0) }
-    for (index, child) in self.items.enumerated() {
-      InsertMenuItemW(hMenu.value, UINT(index), true, &child.info)
-    }
-  }
-}
-
-internal class Win32MenuElement {
-  private var title: [WCHAR]
-  private let submenu: Win32Menu?
-  private let image: BitmapHandle?
-
-  internal var info: MENUITEMINFOW
-
-  private init(title: String, image: Image?, submenu: Win32Menu?, fType: Int32) {
-    self.title = title.wide
-    self.submenu = submenu
-
-    let imageHandle: BitmapHandle?
-    if let bitmap = image?.bitmap {
-      imageHandle = BitmapHandle(from: bitmap)
-    } else {
-      imageHandle = nil
-    }
-    self.image = imageHandle
-
-    self.info = self.title.withUnsafeMutableBufferPointer {
-      MENUITEMINFOW(cbSize: UINT(MemoryLayout<MENUITEMINFOW>.size),
-                    fMask: UINT(MIIM_FTYPE | MIIM_STATE | MIIM_ID | MIIM_STRING | MIIM_SUBMENU | MIIM_DATA | MIIM_BITMAP),
-                    fType: UINT(fType),
-                    fState: UINT(MFS_ENABLED),
-                    wID: UInt32.random(in: .min ... .max),
-                    hSubMenu: submenu?.hMenu.value,
-                    hbmpChecked: nil,
-                    hbmpUnchecked: nil,
-                    dwItemData: 0,
-                    dwTypeData: $0.baseAddress,
-                    cch: UINT(title.count),
-                    hbmpItem: imageHandle?.value)
-    }
-  }
-
-  internal convenience init(_ element: MenuElement) {
-    if let menu = element as? Menu {
-      self.init(title: element.title,
-                image: element.image,
-                submenu: Win32Menu(MenuHandle(owning: CreatePopupMenu()),
-                                   items: menu.children),
-                fType: MFT_STRING)
-    } else {
-      self.init(title: element.title, image: element.image, submenu: nil, fType: MFT_STRING)
-    }
-  }
-}
-
-extension Win32MenuElement {
-  internal static var separator: Win32MenuElement {
-    Win32MenuElement(title: "", image: nil, submenu: nil, fType: MFT_SEPARATOR)
-  }
-
-  internal var isSeparator: Bool {
-    info.fType == MFT_SEPARATOR
-  }
-}
-
 internal final class _MenuBuilder: MenuSystem {
   internal private(set) var hMenu: MenuHandle
   internal private(set) weak var view: View?
@@ -92,6 +20,10 @@ internal final class _MenuBuilder: MenuSystem {
     }
     self.view = view
     self.menus = []
+  }
+
+  override func setNeedsRebuild() {
+    // TODO(compnerd) create the actual menus
   }
 }
 

--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -23,26 +23,25 @@ private let SwiftViewProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubc
       break
     }
 
-    let x = LOWORD(lParam), y = HIWORD(lParam)
-
     // Clear any existing menu.
-    view.menu = nil
+    view.hMenu = nil
 
+    let x = LOWORD(lParam), y = HIWORD(lParam)
     if let actions = interaction.delegate?
                         .contextMenuInteraction(interaction,
                                                 configurationForMenuAtLocation: Point(x: x, y: y))?
                         .actionProvider?([]) {
-      // TODO: handle a possible failure in `CreatePopupMenu`
-      view.menu = Win32Menu(MenuHandle(owning: CreatePopupMenu()),
-                            items: actions.children)
-      _ = TrackPopupMenu(view.menu?.hMenu.value, UINT(TPM_RIGHTBUTTON),
-                        Int32(x), Int32(y), 0, view.hWnd, nil)
     }
+    let position: Point = interaction.location(in: view)
+    _ = TrackPopupMenu(view.hMenu?.value, UINT(TPM_RIGHTBUTTON),
+                       Int32(x), Int32(y), 0, view.hWnd, nil)
 
     return 0
+
   case UINT(WM_COMMAND):
     // TODO: handle menu actions
     break
+
   default:
     break
   }
@@ -238,7 +237,7 @@ public class View: Responder {
     }
   }
 
-  internal var menu: Win32Menu? = nil
+  internal var hMenu: MenuHandle?
 
   // MARK - Creating a View Object
 


### PR DESCRIPTION
This was not completed, and more importantly, took over a name that is
meant to be used in subclasses.  This renames the `menu` item to
`hMenu`, and makes it a menu handle.  The construction of the menu needs
to be plumbed through, but this removes the old handling while the new
handling is implemented.