### PR TITLE
build: silence a pesky warning (NFC)

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -148,6 +148,8 @@ target_sources(SwiftWin32 PRIVATE
   Platform/Win32+PropertyWrappers.swift
   Platform/WindowClass.swift
   Platform/WindowsHandle.swift)
+set_source_files_properties(Support/Error.swift PROPERTIES
+  COMPILE_DEFINITIONS _CRT_SECURE_NO_WARNINGS)
 target_sources(SwiftWin32 PRIVATE
   Support/Array+Extensions.swift
   Support/IndexPath+UIExtensions.swift


### PR DESCRIPTION
The use of `_wcserror` over `_wcserror_s` is intentional as it avoids
having to guess the size of the buffer.