### PR TITLE
build: try to prevent use of static libraries on <5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,5 +62,10 @@ message("--   Swift/COM rG${SWIFT_COM_GIT_REVISION}")
 message("--   swift-log rG${SWIFT_LOG_GIT_REVISION}")
 message("--   Collections rG${COLLECTIONS_GIT_REVISION}")
 
-export(TARGETS SwiftCOM SwiftWin32
-  FILE SwiftWin32Config.cmake)
+if(Swift_COMPILER_VERSION VERSION_LESS 5.5)
+  export(TARGETS Logging SwiftCOM SwiftWin32
+    FILE SwiftWin32Config.cmake)
+else()
+  export(TARGETS SwiftCOM SwiftWin32
+    FILE SwiftWin32Config.cmake)
+endif()

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -31,8 +31,16 @@ _install_target(SwiftCOM)
 
 file(GLOB LOGGING_SOURCES
      ${PROJECT_SOURCE_DIR}/Packages/swift-log/Sources/Logging/*.swift)
-add_library(Logging STATIC
-  ${LOGGING_SOURCES})
+# FIXME(compnerd) 5.5 does not officially support static libraries on Windows
+# either.  The support requires a version strictly greater than 5.5.  Once the
+# branch is introduced, adjust this accordingly.
+if(Swift_COMPILER_VERSION VERSION_LESS 5.5)
+  add_library(Logging SHARED
+    ${LOGGING_SOURCES})
+else()
+  add_library(Logging STATIC
+    ${LOGGING_SOURCES})
+endif()
 
 add_subdirectory(SwiftWin32)
 add_subdirectory(SwiftWin32UI)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -37,6 +37,7 @@ file(GLOB LOGGING_SOURCES
 if(Swift_COMPILER_VERSION VERSION_LESS 5.5)
   add_library(Logging SHARED
     ${LOGGING_SOURCES})
+  _install_target(Logging)
 else()
   add_library(Logging STATIC
     ${LOGGING_SOURCES})


### PR DESCRIPTION
Static library support is experimentally supported on main, which this
project takes advantage of.  Be a bit more careful about enabling the
support to try to keep builds with 5.4.x working.

Fixes: #628