### PR TITLE
Menus and Shortcuts: support window menus

### DIFF
--- a/Sources/SwiftWin32/Platform/Win32+Menu.swift
+++ b/Sources/SwiftWin32/Platform/Win32+Menu.swift
@@ -58,6 +58,11 @@ internal final class _MenuBuilder: MenuSystem {
 
     // Create the new submenus and add them to the root menu:
     append(self.menus, to: self.hMenu)
+
+    if let window = view as? Window {
+      window.hWindowMenu = self.hMenu
+      SetMenu(window.hWnd, window.hWindowMenu?.value)
+    }
   }
 }
 

--- a/Sources/SwiftWin32/Windows and Screens/Window.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Window.swift
@@ -144,9 +144,18 @@ public class Window: View {
 
   // MARK - Configuring the Window
 
+  internal var hWindowMenu: MenuHandle?
+
   /// The root view controller for the window.
   public var rootViewController: ViewController? {
-    didSet { self.rootViewController?.view = self }
+    didSet {
+      self.rootViewController?.view = self
+
+      if let builder = _MenuBuilder(for: self) {
+        self.rootViewController?.buildMenu(with: builder)
+        builder.setNeedsRebuild()
+      }
+    }
   }
 
   /// The position of the window in the z-axis.

--- a/Tests/UICoreTests/WindowTests.swift
+++ b/Tests/UICoreTests/WindowTests.swift
@@ -1,0 +1,49 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+import WinSDK
+@testable import SwiftWin32
+
+final class WindowTests: XCTestCase {
+  func testWindowMenuEmpty() {
+    let viewController = ViewController()
+    viewController.view = View(frame: Rect(x: 0, y: 0, width: 100, height: 100))
+
+    let window = Window(frame: Rect(x: 0, y: 0, width: 200, height: 200))
+    XCTAssertNil(GetMenu(window.hWnd))
+
+    window.rootViewController = viewController
+
+    let hMenu = GetMenu(window.hWnd)
+    XCTAssertEqual(GetMenuItemCount(hMenu), 0)
+  }
+
+  func testWindowMenuWithSubmenus() {
+    // TODO: uncomment when ViewController is `open`
+    /*
+    class ViewControllerWithWindowMenu: ViewController {
+      override func buildMenu(with builder: MenuBuilder) {
+        builder.insertSibling(Menu(title: "title1", children: [Action(title: "action", handler: { _ in })]),
+                              afterMenu: .root)
+        builder.insertSibling(Menu(title: "title2", children: [Command(title: "command", action: { _ in })]),
+                              afterMenu: .root)
+      }
+    }
+
+    let viewController = ViewControllerWithWindowMenu()
+    viewController.view = View(frame: Rect(x: 0, y: 0, width: 100, height: 100))
+
+    let window = Window(frame: Rect(x: 0, y: 0, width: 200, height: 200))
+    window.rootViewController = viewController
+
+    let hMenu = GetMenu(window.hWnd)
+    XCTAssertEqual(GetMenuItemCount(hMenu), 2)
+     */
+  }
+
+  static var allTests = [
+    ("testWindowMenu", testWindowMenuEmpty),
+    ("testWindowMenuWithSubmenus", testWindowMenuWithSubmenus),
+  ]
+}


### PR DESCRIPTION
This adds support for window-level menus, shown on the top of a window.
`_MenuBuilder` is used to construct the menus.