### PR TITLE
Views and Controls: add an implementation of `Offset`

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Offset.swift
+++ b/Sources/SwiftWin32/Views and Controls/Offset.swift
@@ -1,0 +1,60 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import class Foundation.Scanner
+
+/// A structure that specifies an amount to offset a position.
+public struct Offset {
+  // MARK - Initializing Offsets
+
+  public init() {
+    self = .zero
+  }
+
+  public init(horizontal: Double, vertical: Double) {
+    self.horizontal = horizontal
+    self.vertical = vertical
+  }
+
+  // MARK - Getting the Offset Values
+
+  public private(set) var horizontal: Double
+
+  public private(set) var vertical: Double
+}
+
+extension Offset: Equatable {
+  public static func ==(_ lhs: Offset, _ rhs: Offset) -> Bool {
+    return lhs.horizontal == rhs.horizontal && lhs.vertical == rhs.vertical
+  }
+}
+extension Offset {
+  /// Returns a string formatted to contain the data from an offset structure.
+  public static func string(for offset: Offset) -> String {
+    return String(format: "{%.17g, %.17g}", offset.horizontal, offset.vertical)
+  }
+
+  /// Returns an `Offset` structure corresponding to the data in a given string.
+  ///
+  /// In general, you should use this function only to convert strings that were
+  // previously created using the `string(for:)` function.
+  public static func offset(for string: String) -> Offset {
+    let scanner: Scanner = Scanner(string: string)
+    guard scanner.scanCharacter() == "{",
+        let horizontal = scanner.scanDouble(),
+        scanner.scanCharacter() == ",",
+        let vertical = scanner.scanDouble(),
+        scanner.scanCharacter() == "}" else {
+      return .zero
+    }
+    return Offset(horizontal: horizontal, vertical: vertical)
+  }
+}
+
+extension Offset {
+  /// A `Offset` struct whose horizontal and vertical fields are set to the
+  /// value 0.
+  public static var zero: Offset {
+    Offset(horizontal: 0.0, vertical: 0.0)
+  }
+}

--- a/Tests/UICoreTests/OffsetTests.swift
+++ b/Tests/UICoreTests/OffsetTests.swift
@@ -1,0 +1,37 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+import SwiftWin32
+
+final class OffsetTests: XCTestCase {
+  func testOffsetConstructor() {
+    XCTAssertEqual(Offset(), .zero)
+
+    let offset: Offset = Offset(horizontal: .infinity, vertical: .infinity)
+    XCTAssertEqual(offset.horizontal, .infinity)
+    XCTAssertEqual(offset.vertical, .infinity)
+  }
+
+  func testOffsetStringForOffset() {
+    XCTAssertEqual(Offset.offset(for: "invalid"), .zero)
+    XCTAssertEqual(Offset.offset(for: "{"), .zero)
+    XCTAssertEqual(Offset.offset(for: "{1"), .zero)
+    XCTAssertEqual(Offset.offset(for: "{1,"), .zero)
+    XCTAssertEqual(Offset.offset(for: "{1,1"), .zero)
+    XCTAssertEqual(Offset.offset(for: "{1,1}"), Offset(horizontal: 1, vertical: 1))
+  }
+
+  func testOffsetStringRoundtrip() {
+    let offset: Offset = Offset(horizontal: 1, vertical: 2)
+    let string: String = Offset.string(for: offset)
+    XCTAssertEqual(string, "{1.0000000000000, 2.0000000000000}")
+    XCTAssertEqual(offset, Offset.offset(for: string))
+  }
+
+  static var allTests = [
+    ("testOffsetConstructor", testOffsetConstructor),
+    ("testOffsetStringForOffset", testOffsetStringForOffset),
+    ("testOffsetStringRoundtrip", testOffsetStringRoundtrip),
+  ]
+}

--- a/Tests/UICoreTests/OffsetTests.swift
+++ b/Tests/UICoreTests/OffsetTests.swift
@@ -25,7 +25,7 @@ final class OffsetTests: XCTestCase {
   func testOffsetStringRoundtrip() {
     let offset: Offset = Offset(horizontal: 1, vertical: 2)
     let string: String = Offset.string(for: offset)
-    XCTAssertEqual(string, "{1.0000000000000, 2.0000000000000}")
+    XCTAssertEqual(string, "{1, 2}")
     XCTAssertEqual(offset, Offset.offset(for: string))
   }
 


### PR DESCRIPTION
Add a definition for `Offset` and associated tests.  This is needed to
start fleshing out dependencies for `SplitViewController`.