### PR TITLE
build: pin Swift/COM at the same point as the CMake build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let SwiftWin32 = Package(
              .branch("main")),
     .package(url: "https://github.com/compnerd/cassowary.git", .branch("main")),
     .package(name: "SwiftCOM", url: "https://github.com/compnerd/swift-com.git",
-             .branch("main")),
+             .revision("ebbc617d3b7ba3a2023988a74bebd118deea4cc5")),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Ensure that the CMake and SPM builds are at the same point.  If the user
does not initialize the submodules, we would fail to build as the
resolution would pick a different point for Swift/COM.