### PR TITLE
CoreGraphics: make `Vector.zero` public

### DIFF
--- a/Sources/SwiftWin32/CG/Vector.swift
+++ b/Sources/SwiftWin32/CG/Vector.swift
@@ -6,7 +6,9 @@ public struct Vector {
   // MARK - Special Values
 
   /// The vector whose components are both zero.
-  static let zero: Vector = Vector(dx: 0.0, dy: 0.0)
+  public static var zero: Vector {
+    Vector(dx: 0.0, dy: 0.0)
+  }
 
   /// Creates a vector whose components are both zero.
   public init() {

--- a/Tests/CoreGraphicsTests/CoreGraphicsTests.swift
+++ b/Tests/CoreGraphicsTests/CoreGraphicsTests.swift
@@ -280,6 +280,20 @@ final class CoreGraphicsTests: XCTestCase {
     XCTAssertTrue(null1 == null2)
   }
 
+  func testVectorConstructors() {
+    let v1: Vector = Vector()
+    XCTAssertEqual(v1, .zero)
+
+    let v2: Vector = Vector(dx: 0.0 as Float, dy: 0.0 as Float)
+    XCTAssertEqual(v2, .zero)
+
+    let v3: Vector = Vector(dx: 0.0 as Double, dy: 0.0 as Double)
+    XCTAssertEqual(v3, .zero)
+
+    let v4: Vector = Vector(dx: 0, dy: 0)
+    XCTAssertEqual(v4, .zero)
+  }
+
   static var allTests = [
     ("testAffineTransformIdentity", testAffineTransformIdentity),
     ("testAffineTransformIdentityIsIdentity", testAffineTransformIdentityIsIdentity),
@@ -296,5 +310,6 @@ final class CoreGraphicsTests: XCTestCase {
     ("testRectUnion", testRectUnion),
     ("testRectContains", testRectContains),
     ("testRectNonstandardEquality", testRectNonstandardEquality),
+    ("testVectorConstructors", testVectorConstructors)
   ]
 }

--- a/Tests/UICoreTests/CubicTimingParametersTests.swift
+++ b/Tests/UICoreTests/CubicTimingParametersTests.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import XCTest
-@testable import SwiftWin32
+import SwiftWin32
 
 final class CubicTimingParametersTests: XCTestCase {
   func testDefaultState() {

--- a/Tests/UICoreTests/SpringTimingParametersTests.swift
+++ b/Tests/UICoreTests/SpringTimingParametersTests.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import XCTest
-@testable import SwiftWin32
+import SwiftWin32
 
 final class SpringTimingParametersTests: XCTestCase {
   func testDefaultState() {


### PR DESCRIPTION
This member is meant to be public, but was accidentally internal.