### PR TITLE
Views and Control: correct a method name in `View`

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/View.swift
+++ b/Sources/SwiftWin32/Views and Controls/View.swift
@@ -598,7 +598,7 @@ public class View: Responder {
   }
 
   /// Informs the view that its window object changed.
-  public func diMoveToWindow() {
+  public func didMoveToWindow() {
   }
 
   // MARK - Configuring Content Margins


### PR DESCRIPTION
Correct the hook-point `didMoveToWindow` in `View`.