### PR TITLE
App and Environment: avoid a deprecation warning

### DIFF
--- a/Sources/SwiftWin32/App and Environment/TraitCollection.swift
+++ b/Sources/SwiftWin32/App and Environment/TraitCollection.swift
@@ -198,7 +198,7 @@ private func GetCurrentColorScheme() -> UserInterfaceStyle {
 }
 
 private func GetCurrentDeviceFamily() -> UserInterfaceIdiom {
-  return GetSystemMetrics(SM_TABLETPC) == 0 ? .unspecified : .pad
+  return GetSystemMetrics(SM_TABLETPC) == 0 ? .unspecified : .tablet
 }
 
 private func GetCurrentAccessibilityContrast() -> AccessibilityContrast {


### PR DESCRIPTION
Replace `.pad` with `.tablet`.  NFC