### PR TITLE
App and Environment: use `renamed:` variant of availability

### DIFF
--- a/Sources/SwiftWin32/App and Environment/TraitCollection.swift
+++ b/Sources/SwiftWin32/App and Environment/TraitCollection.swift
@@ -60,7 +60,7 @@ public enum UserInterfaceIdiom: Int {
   /// An interface designed for a phone.
   case phone
 
-  @available(*, deprecated, message: "Use UserInterfaceIdiom.tablet")
+  @available(*, deprecated, renamed: "UserInterfaceIdiom.tablet")
   case pad
 
   /// An interface designed for a TV.
@@ -69,7 +69,7 @@ public enum UserInterfaceIdiom: Int {
   /// An interface designed for a car display.
   case car
 
-  @available(*, deprecated, message: "Use UserInterfaceIdiom.desktop")
+  @available(*, deprecated, renamed: "UserInterfaceIdiom.desktop")
   case mac
 
   /// An interface designed for a tablet.


### PR DESCRIPTION
Indicate the renaming via the availability attribute rather than the
custom message for a more homogeneous messaging.