### PR TITLE
actions: add an additional documentation module

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -61,13 +61,14 @@ jobs:
 
     - name: Generate Documentation
       run: |
+        swift doc generate Sources\SwiftWin32\CA --module-name CoreAnimation --output site\CoreAnimation --base-url https://compnerd.github.io/swift-win32/CoreAnimation
         swift doc generate Sources\SwiftWin32\CG --module-name CoreGraphics --output site\CoreGraphics --base-url https://compnerd.github.io/swift-win32/CoreGraphics
         swift doc generate Sources\SwiftWin32 --module-name SwiftWin32 --output site\SwiftWin32 --base-url https://compnerd.github.io/swift-win32/SwiftWin32
         swift doc generate Sources\SwiftWin32UI --module-name SwiftWin32UI --output site\SwiftWin32UI --base-url https://compnerd.github.io/swift-win32/SwiftWin32UI
 
     - name: Post-Process
       run: |
-        foreach ($module in "CoreGraphics","SwiftWin32","SwiftWin32UI") {
+        foreach ($module in "CoreAnimation","CoreGraphics","SwiftWin32","SwiftWin32UI") {
           Get-ChildItem -Path site\$module -Recurse -File -Include "*.md" -Exclude Home.md,_Footer.md,_Sidebar.md,index.md | ForEach-Object {
             Set-Content $_.FullName -value @"
         ---


### PR DESCRIPTION
Although the interfaces here are not particularly exposed as part of the
SwiftWin32 interfaces, this adds a separate module for the purposes of
documentation hierarchy.  It makes it easier to locate the documentation
when needed.