### PR TITLE
build: add a CMakePresets for the project

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,28 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "Default",
+      "displayName": "Release Build (Ninja)",
+      "description": "Defaults",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/.build/x86_64-unknown-windows-msvc/Release",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "YES",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_Swift_FLAGS": "-sdk $env{SDKROOT}"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "Default",
+      "configurePreset": "Default"
+    }
+  ]
+}


### PR DESCRIPTION
This adds a default configuration that is recommended as a preset:
- Release Build with Ninja, with `-sdk %SDKROOT%` as the Swift flags.

This should help make it get started with the CMake based build with
VSCode or any IDE which supports CMakePresets.