### PR TITLE
Support: add some helpers for time conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -98,6 +98,10 @@ let SwiftWin32 = Package(
       dependencies: ["SwiftWin32"]
     ),
     .testTarget(
+      name: "SupportTests",
+      dependencies: ["SwiftWin32"]
+    ),
+    .testTarget(
       name: "UICoreTests",
       dependencies: ["SwiftWin32", "TestUtilities"]
     )

--- a/Sources/SwiftWin32/Support/Date+Extensions.swift
+++ b/Sources/SwiftWin32/Support/Date+Extensions.swift
@@ -1,0 +1,54 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import WinSDK
+
+import struct Foundation.Date
+import struct Foundation.TimeInterval
+
+// 100 nanosecond ticks
+@_transparent
+internal var WindowsTick: Double { 10_000_000 }
+
+// NT to Unix Epoch (seconds)
+@_transparent
+internal var NTToUnixEpochBias: Double { 11_644_473_600 }
+
+extension FILETIME {
+  @inline(__always)
+  internal init(_ systemTime: SYSTEMTIME) {
+    self = FILETIME()
+    withUnsafePointer(to: systemTime) {
+      guard SystemTimeToFileTime($0, &self) else {
+        fatalError("SystemTimeToFileTime: \(Error(win32: GetLastError()))")
+      }
+    }
+  }
+
+  @inline(__always)
+  internal init(timeIntervalSince1970 interval: TimeInterval) {
+    let value = UInt64((interval + NTToUnixEpochBias) * WindowsTick)
+    self = FILETIME(dwLowDateTime: DWORD((value >> 0) & 0xffffffff),
+                    dwHighDateTime: DWORD((value >> 32) & 0xffffffff))
+  }
+
+  @inline(__always)
+  internal var timeIntervalSince1970: TimeInterval {
+    var ulTime: ULARGE_INTEGER = ULARGE_INTEGER()
+    ulTime.LowPart = self.dwLowDateTime
+    ulTime.HighPart = self.dwHighDateTime
+    return Double(ulTime.QuadPart) / WindowsTick - NTToUnixEpochBias
+  }
+}
+
+extension SYSTEMTIME {
+  @inline(__always)
+  internal init(_ fileTime: FILETIME) {
+    self = SYSTEMTIME()
+    withUnsafePointer(to: fileTime) {
+      guard FileTimeToSystemTime($0, &self) else {
+        fatalError("FileTimeToSystemTime: \(Error(win32: GetLastError()))")
+      }
+    }
+  }
+}

--- a/Tests/SupportTests/DateTests.swift
+++ b/Tests/SupportTests/DateTests.swift
@@ -1,0 +1,86 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+import WinSDK
+import struct Foundation.Date
+@testable import SwiftWin32
+
+final class DateTests: XCTestCase {
+  func testFileTimeConstruction() {
+    XCTAssertEqual(FILETIME(timeIntervalSince1970: 0).timeIntervalSince1970, 0)
+  }
+
+  func testUnixEpoch() {
+    let ftUnixEpoch: FILETIME = FILETIME(timeIntervalSince1970: 0)
+    XCTAssertEqual(ftUnixEpoch.dwLowDateTime, 3577643008)
+    XCTAssertEqual(ftUnixEpoch.dwHighDateTime, 27111902)
+
+    let stUnixEpoch: SYSTEMTIME = SYSTEMTIME(ftUnixEpoch)
+    XCTAssertEqual(stUnixEpoch.wYear, 1970)
+    XCTAssertEqual(stUnixEpoch.wMonth, 1)
+    XCTAssertEqual(stUnixEpoch.wDayOfWeek, 4)
+    XCTAssertEqual(stUnixEpoch.wDay, 1)
+    XCTAssertEqual(stUnixEpoch.wHour, 0)
+    XCTAssertEqual(stUnixEpoch.wMinute, 0)
+    XCTAssertEqual(stUnixEpoch.wSecond, 0)
+    XCTAssertEqual(stUnixEpoch.wMilliseconds, 0)
+  }
+
+  func testSystemTimeConversion() {
+    let stTimeStamp: SYSTEMTIME =
+        SYSTEMTIME(wYear: 2020, wMonth: 11, wDayOfWeek: 0, wDay: 7,
+                   wHour: 0, wMinute: 0, wSecond: 0, wMilliseconds: 0)
+    XCTAssertEqual(FILETIME(stTimeStamp).timeIntervalSince1970,
+                   1604707200)
+  }
+
+  func testFileTimeConversion() {
+    let ftTimeStamp: FILETIME = FILETIME(timeIntervalSince1970: 1604707200)
+    let stTimeStamp: SYSTEMTIME = SYSTEMTIME(ftTimeStamp)
+
+    XCTAssertEqual(stTimeStamp.wYear, 2020)
+    XCTAssertEqual(stTimeStamp.wMonth, 11)
+
+    // We cannot check the day of week because it is ignored on the conversion
+    // and we are going from UTC to local time zone to UTC, which changes the
+    // day.
+    /* XCTAssertEqual(stTimeStamp.wDayOfWeek, 0) */
+
+    XCTAssertEqual(stTimeStamp.wDay, 7)
+    XCTAssertEqual(stTimeStamp.wHour, 0)
+    XCTAssertEqual(stTimeStamp.wMinute, 0)
+    XCTAssertEqual(stTimeStamp.wSecond, 0)
+    XCTAssertEqual(stTimeStamp.wMilliseconds, 0)
+  }
+
+  func testRoundTrip() {
+    let ftSystemTimeInitial: SYSTEMTIME =
+      SYSTEMTIME(wYear: 2020, wMonth: 11, wDayOfWeek: 6, wDay: 7,
+                 wHour: 0, wMinute: 0, wSecond: 0, wMilliseconds: 0)
+    let ftSystemTimeConverted: SYSTEMTIME =
+        SYSTEMTIME(FILETIME(ftSystemTimeInitial))
+
+    XCTAssertEqual(ftSystemTimeInitial.wYear, ftSystemTimeConverted.wYear)
+    XCTAssertEqual(ftSystemTimeInitial.wMonth, ftSystemTimeConverted.wMonth)
+
+    // We cannot check the day of week because it is ignored on the conversion
+    // and we are going from UTC to local time zone to UTC, which changes the
+    // day.
+    /* XCTAssertEqual(ftSystemTimeInitial.wDayOfWeek, ftSystemTimeConverted.wDayOfWeek) */
+
+    XCTAssertEqual(ftSystemTimeInitial.wDay, ftSystemTimeConverted.wDay)
+    XCTAssertEqual(ftSystemTimeInitial.wHour, ftSystemTimeConverted.wHour)
+    XCTAssertEqual(ftSystemTimeInitial.wMinute, ftSystemTimeConverted.wMinute)
+    XCTAssertEqual(ftSystemTimeInitial.wSecond, ftSystemTimeConverted.wSecond)
+    XCTAssertEqual(ftSystemTimeInitial.wMilliseconds, ftSystemTimeConverted.wMilliseconds)
+  }
+
+  static var allTests = [
+    ("testFileTimeConstruction", testFileTimeConstruction),
+    ("testUnixEpoch", testUnixEpoch),
+    ("testSystemTimeConversion", testSystemTimeConversion),
+    ("testFileTimeConversion", testFileTimeConversion),
+    ("testRoundTrip", testRoundTrip),
+  ]
+}


### PR DESCRIPTION
This adds some conversion helpers for `FILETIME` and `SYSTEMTIME`.
These are intended to help support adding accessors for the `DatePicker`
control.