### PR TITLE
DatePicker: add accessors for the `DatePicker`

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -144,6 +144,7 @@ target_sources(SwiftWin32 PRIVATE
   Platform/WindowsHandle.swift)
 target_sources(SwiftWin32 PRIVATE
   Support/Array+Extensions.swift
+  Support/Date+Extensions.swift
   Support/IndexPath+UIExtensions.swift
   Support/Logging.swift
   Support/Rect+UIExtensions.swift

--- a/Sources/SwiftWin32/Views and Controls/DatePicker.swift
+++ b/Sources/SwiftWin32/Views and Controls/DatePicker.swift
@@ -3,6 +3,8 @@
 
 import WinSDK
 
+import struct Foundation.Date
+
 private let SwiftDatePickerProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) in
   let datepicker: DatePicker? =
       unsafeBitCast(dwRefData, to: AnyObject.self) as? DatePicker
@@ -22,7 +24,40 @@ public class DatePicker: Control {
   private static let style: WindowStyle =
       (base: WS_POPUP | WS_TABSTOP, extended: 0)
 
-  /// Configuring the Date Picker Style
+  // MARK - Managing the Date and Calendar
+
+  /// The date displayed by the date picker.
+  public var date: Date {
+    get {
+      var stDateTime: SYSTEMTIME = SYSTEMTIME()
+      // FIXME(compnerd) ensure that GDT_VALID is returned
+      _ = withUnsafeMutablePointer(to: &stDateTime) {
+        SendMessageW(self.hWnd, UINT(DTM_GETSYSTEMTIME),
+                     WPARAM(0), LPARAM(UInt(bitPattern: $0)))
+      }
+
+      let ftDateTime: FILETIME = FILETIME(stDateTime)
+      return Date(timeIntervalSince1970: ftDateTime.timeIntervalSince1970)
+    }
+    set { self.setDate(newValue, animated: false) }
+  }
+
+  /// Sets the date to display in the date picker, with an option to animate the
+  /// setting.
+  public func setDate(_ date: Date, animated: Bool) {
+    assert(!animated, "not yet implemented")
+
+    var ftSystemTime: FILETIME =
+        FILETIME(timeIntervalSince1970: date.timeIntervalSince1970)
+    let stSystemTime: SYSTEMTIME = SYSTEMTIME(ftSystemTime)
+
+    _ = withUnsafePointer(to: stSystemTime) {
+      SendMessageW(self.hWnd, UINT(DTM_SETSYSTEMTIME),
+                   WPARAM(GDT_VALID), LPARAM(UInt(bitPattern: $0)))
+    }
+  }
+
+  // MARK - Configuring the Date Picker Style
 
   public private(set) var datePickerStyle: DatePickerStyle = .inline
   public private(set) var preferredDatePickerStyle: DatePickerStyle = .automatic {

--- a/Tests/UICoreTests/DatePickerTests.swift
+++ b/Tests/UICoreTests/DatePickerTests.swift
@@ -1,0 +1,31 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+import WinSDK
+import Foundation
+@testable import SwiftWin32
+
+final class DatePickerTests: XCTestCase {
+  func testDateAccessors() {
+    var ftSystemTime: FILETIME = FILETIME()
+    GetSystemTimeAsFileTime(&ftSystemTime)
+    var ftLocalSystemTime: FILETIME = FILETIME()
+    FileTimeToLocalFileTime(&ftSystemTime, &ftLocalSystemTime)
+
+    let datepicker: DatePicker = DatePicker(frame: .zero)
+
+    let time: Date =
+        Date(timeIntervalSince1970: ftLocalSystemTime.timeIntervalSince1970)
+    // FIXME(compnerd) can we use a tigher bounds?
+    XCTAssertTrue(datepicker.date.distance(to: time) <= 1.0)
+
+    datepicker.date = Date(timeIntervalSinceReferenceDate: 410220000)
+    XCTAssertEqual(datepicker.date,
+                   Date(timeIntervalSinceReferenceDate: 410220000))
+  }
+
+  static var allTests = [
+    ("testDateAccessors", testDateAccessors),
+  ]
+}


### PR DESCRIPTION
Add the `date` property and `setDate(_:animated:)` function to provide
access to the value selected by the `DatePicker` control.

Fixes: #677