### PR TITLE
DatePicker: silence a warning (NFC)

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/DatePicker.swift
+++ b/Sources/SwiftWin32/Views and Controls/DatePicker.swift
@@ -47,7 +47,7 @@ public class DatePicker: Control {
   public func setDate(_ date: Date, animated: Bool) {
     assert(!animated, "not yet implemented")
 
-    var ftSystemTime: FILETIME =
+    let ftSystemTime: FILETIME =
         FILETIME(timeIntervalSince1970: date.timeIntervalSince1970)
     let stSystemTime: SYSTEMTIME = SYSTEMTIME(ftSystemTime)
 


### PR DESCRIPTION
Silence a warning about an unmutated `var` by changing it to `let`.