### PR TITLE
App and Environment: shuffle & extend `ContentSizeCategory`

### DIFF
--- a/Sources/SwiftWin32/App and Environment/Application.swift
+++ b/Sources/SwiftWin32/App and Environment/Application.swift
@@ -1,6 +1,113 @@
 // Copyright © 2019 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
+import class Foundation.NSNotification
+
+/// Constants that indicate the preferred size of your content.
+public struct ContentSizeCategory: Equatable, Hashable, RawRepresentable {
+  public typealias RawValue = String
+
+  public var rawValue: RawValue
+
+  public init(rawValue: RawValue) {
+    self.rawValue = rawValue
+  }
+}
+
+extension ContentSizeCategory {
+  // MARK - Font Sizes
+
+  /// An unspecified font size.
+  public static var unspecified: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "_UICTContentSizeCategoryUnspecified")
+  }
+
+  /// An extra-small font.
+  public static var extraSmall: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXS")
+  }
+
+  /// A small font.
+  public static var small: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryS")
+  }
+
+  /// A medium-sized font.
+  public static var medium: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryM")
+  }
+
+  /// A large font.
+  public static var large: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryL")
+  }
+
+  /// An extra-large font.
+  public static var extraLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXL")
+  }
+
+  /// A font that is larger than the extra-large font but smaller than the
+  /// largest font size available.
+  public static var extraExtraLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXXL")
+  }
+
+  /// The largest font size.
+  public static var extraExtraExtraLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXXXL")
+  }
+
+  // MARK - Accessibility Sizes
+
+  /// A medium font size that reflects the current accessibility settings.
+  public static var accessibilityMedium: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityM")
+  }
+
+  /// A large font size that reflects the current accessibility settings.
+  public static var accessibilityLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityL")
+  }
+
+  /// An extra-large font size that reflects the current accessibility settings.
+  public static var accessibilityExtraLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityXL")
+  }
+
+  /// A font that is larger than the extra-large font but not the largest
+  /// available, reflecting the current accessibility settings.
+  public static var accessibilityExtraExtraLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityXXL")
+  }
+
+  /// The largest font size that reflects the current accessibility settings.
+  public static var accessibilityExtraExtraExtraLarge: ContentSizeCategory {
+    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityXXXL")
+  }
+
+  // MARK - Font Size Change Notifications
+
+  /// A notification that posts when the user changes the preferred content size
+  /// setting.
+  ///
+  /// This notification is sent when the value in the
+  /// `preferredContentSizeCategory` property changes. The `userInfo` dictionary
+  /// of the notification contains the `newValueUserInfoKey` key, which reflects
+  /// the new setting.
+  public static var didChangeNotification: NSNotification.Name {
+    NSNotification.Name(rawValue: "UIContentSizeCategoryDidChangeNotification")
+  }
+
+  /// A key that reflects the new preferred content size.
+  ///
+  /// This key's value is an `NSString` object that reflects the new value of
+  /// the `preferredContentSizeCategory` property.
+  public static var newValueUserInfoKey: String {
+    "UIContentSizeCategoryNewValueUserInfoKey"
+  }
+}
+
 /// The centralised point of control and coordination for running applications.
 open class Application: Responder {
   internal var information: Information?

--- a/Sources/SwiftWin32/App and Environment/TraitCollection.swift
+++ b/Sources/SwiftWin32/App and Environment/TraitCollection.swift
@@ -110,70 +110,8 @@ public enum ForceTouchCapability: Int {
   case unspecified
   case available
   case unavailable
-}
 
-public struct ContentSizeCategory: Equatable, Hashable, RawRepresentable {
-  public typealias RawValue = String
 
-  public var rawValue: RawValue
-
-  public init(rawValue: RawValue) {
-    self.rawValue = rawValue
-  }
-}
-
-extension ContentSizeCategory {
-  public static var unspecified: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "_UICTContentSizeCategoryUnspecified")
-  }
-
-  public static var extraSmall: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXS")
-  }
-
-  public static var small: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryS")
-  }
-
-  public static var medium: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryM")
-  }
-
-  public static var large: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryL")
-  }
-
-  public static var extraLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXL")
-  }
-
-  public static var extraExtraLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXXL")
-  }
-
-  public static var extraExtraExtraLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryXXXL")
-  }
-
-  public static var accessibilityMedium: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityM")
-  }
-
-  public static var accessibilityLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityL")
-  }
-
-  public static var accessibilityExtraLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityXL")
-  }
-
-  public static var accessibilityExtraExtraLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityXXL")
-  }
-
-  public static var accessibilityExtraExtraExtraLarge: ContentSizeCategory {
-    ContentSizeCategory(rawValue: "UICTContentSizeCategoryAccessibilityXXXL")
-  }
 }
 
 private func GetCurrentColorScheme() -> UserInterfaceStyle {


### PR DESCRIPTION
This moves the source file used for the `ContentSizeCategory` extensible
enumeration.  It adds some missing interfaces as well.