### PR TITLE
Update Screen.swift

### DIFF
--- a/Sources/SwiftWin32/Windows and Screens/Screen.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Screen.swift
@@ -42,7 +42,7 @@ public final class Screen {
       if (withUnsafeMutablePointer(to: &info) {
         let pMemoryInfo: UnsafeMutablePointer<MONITORINFO> =
             UnsafeMutableRawPointer($0).assumingMemoryBound(to: MONITORINFO.self)
-        GetMonitorInfoW(hMonitor, pMemoryInfo)
+        return GetMonitorInfoW(hMonitor, pMemoryInfo)
       }) == false { return false }
 
       let szDevice: String = withUnsafePointer(to: &info.szDevice) {

--- a/Sources/SwiftWin32/Windows and Screens/Screen.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Screen.swift
@@ -40,9 +40,9 @@ public final class Screen {
       var info: MONITORINFOEXW = MONITORINFOEXW()
       info.cbSize = DWORD(MemoryLayout<MONITORINFOEXW>.size)
       if (withUnsafeMutablePointer(to: &info) {
-        $0.withMemoryRebound(to: MONITORINFO.self, capacity: 1) {
-          GetMonitorInfoW(hMonitor, $0)
-        }
+        let pMemoryInfo: UnsafeMutablePointer<MONITORINFO> =
+            UnsafeMutableRawPointer($0).assumingMemoryBound(to: MONITORINFO.self)
+        GetMonitorInfoW(hMonitor, pMemoryInfo)
       }) == false { return false }
 
       let szDevice: String = withUnsafePointer(to: &info.szDevice) {


### PR DESCRIPTION
Avoid rebinding the memory and instead create a new pointer to the memory at the same location.  This avoids triggering an assertion failure in the newer runtimes.