### PR TITLE
CI: disable fast fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - branch: swift-5.4.3-release


### PR DESCRIPTION
Rather than failing immediately on the first build failure, allow completion.