### PR TITLE
TextView: remove unnecessary casting

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/TextView.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextView.swift
@@ -36,8 +36,7 @@ public class TextView: View {
 
     // Disable compatibility with the original Rich Edit and use the extended
     // text limit.
-    _ = SendMessageW(self.hWnd, UINT(EM_EXLIMITTEXT),
-                     WPARAM(0), LPARAM(bitPattern: UInt64(bitPattern: -1)))
+    _ = SendMessageW(self.hWnd, UINT(EM_EXLIMITTEXT), WPARAM(0), LPARAM(-1))
   }
 
   public func scrollRangeToVisible(_ range: NSRange) {

--- a/Tests/UICoreTests/TextViewTests.swift
+++ b/Tests/UICoreTests/TextViewTests.swift
@@ -1,0 +1,23 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+import WinSDK
+@testable import SwiftWin32
+
+final class TextViewTests: XCTestCase {
+  override class func setUp() {
+    let hModule: HMODULE = "Msftedit.dll".withCString(encodedAs: UTF16.self) {
+      LoadLibraryW($0)
+    }
+  }
+
+  func testConstruct() {
+    let view: TextView = TextView(frame: .zero)
+    XCTAssertNotEqual(view.hWnd, INVALID_HANDLE_VALUE)
+  }
+
+  static var allTests = [
+    ("testConstruct", testConstruct),
+  ]
+}


### PR DESCRIPTION
This would end up truncating when trying to be 32-bit clean.  Instead,
just drop the casts.