### PR TITLE
Views and Control: correct `Label` content access

### DIFF
--- a/Sources/SwiftWin32/Views and Controls/Label.swift
+++ b/Sources/SwiftWin32/Views and Controls/Label.swift
@@ -26,8 +26,10 @@ public class Label: Control {
   public var text: String? {
     get {
       let szLength: Int32 = GetWindowTextLengthW(self.hWnd_)
+      guard szLength > 0 else { return nil }
+
       let buffer: [WCHAR] = Array<WCHAR>(unsafeUninitializedCapacity: Int(szLength) + 1) {
-        $1 = Int(GetWindowTextW(self.hWnd_, $0.baseAddress!, CInt($0.count)))
+        $1 = Int(GetWindowTextW(self.hWnd_, $0.baseAddress!, CInt($0.count))) + 1
       }
       return String(decodingCString: buffer, as: UTF16.self)
     }


### PR DESCRIPTION
`GetWindowTextW` is documented as:
```
If the function succeeds, the return value is the length, in characters,
of the copied string, not including the terminating null character.
```
Ensure that we properly account for the trailing null character.