### PR TITLE
tests: ensure that the setup succeeded when testing

### DIFF
--- a/Tests/UICoreTests/TextViewTests.swift
+++ b/Tests/UICoreTests/TextViewTests.swift
@@ -6,13 +6,17 @@ import WinSDK
 @testable import SwiftWin32
 
 final class TextViewTests: XCTestCase {
+  static var hModule: HMODULE?
+
   override class func setUp() {
-    let hModule: HMODULE = "Msftedit.dll".withCString(encodedAs: UTF16.self) {
+    TextViewTests.hModule = "Msftedit.dll".withCString(encodedAs: UTF16.self) {
       LoadLibraryW($0)
     }
   }
 
-  func testConstruct() {
+  func testConstruct() throws {
+    try XCTSkipIf(TextViewTests.hModule == nil, "Msftedit.dll not loaded")
+
     let view: TextView = TextView(frame: .zero)
     XCTAssertNotEqual(view.hWnd, INVALID_HANDLE_VALUE)
   }


### PR DESCRIPTION
We need to ensure that the richedit module is loaded before we attempt
to use the richedit based controls.  This is normally taken care of
during the application setup, but because the tests do not run as an
application, we need to handle this in the test harness setup.  The
tests should subsequently verify that the module was loaded.