### PR TITLE
Platform: mark `WindowClass` as `final`

### DIFF
--- a/Sources/SwiftWin32/Platform/WindowClass.swift
+++ b/Sources/SwiftWin32/Platform/WindowClass.swift
@@ -6,7 +6,7 @@ import WinSDK
 internal typealias WindowProc =
     @convention(c) (HWND?, UINT, WPARAM, LPARAM) -> LRESULT
 
-internal class WindowClass {
+internal final class WindowClass {
   internal var name: [WCHAR]
 
   internal var hInstance: HINSTANCE?


### PR DESCRIPTION
This class should not be extended as it is an internal implementation
detail.  Mark the class as `final`.