### PR TITLE
CI: adjust azure pipelines setup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,8 +51,8 @@ steps:
 
 - script: |
     curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/ucrt.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
-    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/visualc.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
-    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/visualc.apinotes" -o "%VCToolsInstallDir%\include\visualc.apinotes"
+    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/vcruntime.modulemap" -o "%VCToolsInstallDir%\include\module.modulemap"
+    curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/vcruntime.apinotes" -o "%VCToolsInstallDir%\include\vcruntime.apinotes"
     curl -L "https://raw.githubusercontent.com/apple/swift/main/stdlib/public/Platform/winsdk.modulemap" -o "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
   displayName: Configure SDK
 


### PR DESCRIPTION
Since we explicitly download the latest modulemap from the Swift repository,
update for the restructuring that is in progress.