### PR TITLE
Platform: account for nul terminator

### DIFF
--- a/Sources/SwiftWin32/Platform/Win32+PropertyWrappers.swift
+++ b/Sources/SwiftWin32/Platform/Win32+PropertyWrappers.swift
@@ -19,7 +19,7 @@ public struct _Win32WindowText {
       guard szLength > 0 else { return nil }
 
       let buffer: [WCHAR] = Array<WCHAR>(unsafeUninitializedCapacity: Int(szLength) + 1) {
-        $1 = Int(GetWindowTextW(view.hWnd, $0.baseAddress!, CInt($0.count)))
+        $1 = Int(GetWindowTextW(view.hWnd, $0.baseAddress!, CInt($0.count))) + 1
       }
       return String(decodingCString: buffer, as: UTF16.self)
     }


### PR DESCRIPTION
Ensure that we allocate the space for the trailing nul terminator in the string.  We would otherwise be off by one when converting the string.