### PR TITLE
Support for Apple Silicon ARM CPUs

### DIFF
--- a/cmake/Modules/SwiftSupport.cmake
+++ b/cmake/Modules/SwiftSupport.cmake
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #]]
 
 # Returns the architecture name in a variable
-# (Apple Silicon) ARM CPUs supported [x86_64]
 #
 # Usage:
 #   get_swift_host_arch(result_var_name)

--- a/cmake/Modules/SwiftSupport.cmake
+++ b/cmake/Modules/SwiftSupport.cmake
@@ -6,6 +6,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #]]
 
 # Returns the architecture name in a variable
+# (Apple Silicon) ARM CPUs supported [x86_64]
 #
 # Usage:
 #   get_swift_host_arch(result_var_name)
@@ -29,6 +30,8 @@ function(get_swift_host_arch result_var_name)
     set("${result_var_name}" "armv7" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
     set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ARM64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
     set("${result_var_name}" "x86_64" PARENT_SCOPE)
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")


### PR DESCRIPTION
### Solution
While building the project with `cmake`, an unexpected error occurred in relation to my laptop CPU architecture. Currently, I'm running a Parallels VM of Windows 11 on a M1 Max MacBook Pro. As such, I discovered that the Apple Silicon `ARM64` architecture was not supported - possible use cases and scenarios include running windows on a Virtual Machine (VM), dual-boot or on Apple Bootcamp. Therefore, I have added the `ARM64 [x86_64]` CPU type under `.\cmake\Modules\SwiftSupport.cmake`. After trying and testing it out, it now works with support for M1/M2 Macs.

### Original Error
The original error occurred while running the suggested session line:
`cmake -B build -D BUILD_SHARED_LIBS=YES -D CMAKE_BUILD_TYPE=Release -D CMAKE_Swift_FLAGS="-sdk %SDKROOT%" -G Ninja -S .`

This was the output at the end:
```
CMake Error at cmake/Modules/SwiftSupport.cmake:41 (message):
  Unrecognized architecture on host system: ARM64
Call Stack (most recent call first):
  cmake/Modules/SwiftSupport.cmake:80 (get_swift_host_arch)
  Packages/swift-collections/Sources/Collections/CMakeLists.txt:18 (_install_target)
```