### PR TITLE
Platform: avoid warning from use of `_strerror_s`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: '-Xswiftc -gnone'
+            options: '-Xswiftc -threads -Xswiftc 1 -Xswiftc -j1 -Xswiftc -gnone'
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: '-Xswiftc -sil-verify-none'
+            options: '-Xswiftc -Xfrontend -Xswiftc -sil-verify-none'
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: '-Xswiftc -Xfrontend -Xswiftc -sil-verify-none'
+            options: ''
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: '-Xswiftc -j1 -Xswiftc -gnone'
+            options: '-Xswiftc -sil-verify-none'
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: ''
+            options: '-gnone'
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: '-Xswiftc -threads -Xswiftc 1 -Xswiftc -j1 -Xswiftc -gnone'
+            options: '-Xswiftc -j1 -Xswiftc -gnone'
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
           - branch: swift-5.6.3-release
             tag: 5.6.3-RELEASE
-            options: '-gnone'
+            options: '-Xswiftc -gnone'
 
           - branch: swift-5.7.3-release
             tag: 5.7.3-RELEASE

--- a/Sources/SwiftWin32/Platform/Error.swift
+++ b/Sources/SwiftWin32/Platform/Error.swift
@@ -47,7 +47,7 @@ extension Error: CustomStringConvertible {
 
       // MSDN indicates that the returned string can have a maximum of 94
       // characters, so allocate 95 characters.
-#if swift(>=5.6)
+#if swift(>=5.7)
       return withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: 95) {
         let result: errno_t = _wcserror_s($0.baseAddress, $0.count, errno)
         guard result == 0 else { return short }

--- a/Sources/SwiftWin32/Platform/Error.swift
+++ b/Sources/SwiftWin32/Platform/Error.swift
@@ -45,12 +45,22 @@ extension Error: CustomStringConvertible {
     case .errno(let errno):
       short = "errno \(errno)"
 
-      // Short-circuit the formatting path as this does not do a `LocalAlloc`
-      // and does not use `FormatMessageW`.
-      guard let description = _wcserror(errno) else {
-        return short
+      // MSDN indicates that the returned string can have a maximum of 94
+      // characters, so allocate 95 characters.
+#if swift(>=5.6)
+      return withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: 95) {
+        let result: errno_t = _wcserror_s($0.baseAddress, $0.count, errno)
+        guard result == 0 else { return short }
+        return "\(short) - \(String(decodingCString: $0.baseAddress!, as: UTF16.self))"
       }
-      return "\(short) - \(String(decodingCString: description, as: UTF16.self))"
+#else
+      let buffer: UnsafeMutablePointer<wchar_t> = .allocate(capacity: 95)
+      defer { buffer.deallocate() }
+
+      let result: errno_t = _wcserror_s(buffer, 95, errno)
+      guard result == 0 else { return short }
+      return "\(short) - \(String(decodingCString: buffer, as: UTF16.self))"
+#endif
 
     case .win32(let error):
       short = "Win32 Error \(error)"


### PR DESCRIPTION
The buffer size for `_strerror` and `_wcserror` are fixed at 94 characters.  Use this to allocate the fixed size buffer and build the error message using `_wcserror_s` to avoid the warning as the allocation should be small enough to get stack promoted.