### PR TITLE
GHA: name the jobs (NFC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
             tag: DEVELOPMENT-SNAPSHOT-2023-04-01-a
             options: ''
 
+    name: Swift ${{ matrix.tag }}
+
     steps:
     - uses: compnerd/gha-setup-swift@main
       with:


### PR DESCRIPTION
This simply renders a pretty name for the branch when building to identify the current branch being buiilt.