### PR TITLE
GHA: add a 5.8 build train

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
             tag: 5.7.3-RELEASE
             options: ''
 
+          - branch: swift-5.8-release
+            tag: 5.8-RELEASE
+            options: ''
+
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2023-04-01-a
             options: ''


### PR DESCRIPTION
Introduce a 5.8 release train to the build matrix.