### PR TITLE
View Controller: account for no title condition

### DIFF
--- a/Sources/SwiftWin32/View Controllers/ViewController.swift
+++ b/Sources/SwiftWin32/View Controllers/ViewController.swift
@@ -177,8 +177,10 @@ public class ViewController: Responder {
   public var title: String? {
     get {
       let szLength: Int32 = GetWindowTextLengthW(view.hWnd)
+      guard szLength > 0 else { return nil }
+
       let buffer: [WCHAR] = Array<WCHAR>(unsafeUninitializedCapacity: Int(szLength) + 1) {
-        $1 = Int(GetWindowTextW(view.hWnd, $0.baseAddress!, CInt($0.count)))
+        $1 = Int(GetWindowTextW(view.hWnd, $0.baseAddress!, CInt($0.count))) + 1
       }
       return String(decodingCString: buffer, as: UTF16.self)
     }


### PR DESCRIPTION
If the hWnd does not have a window title, assume that there is no title and return `nil`.  Account for the trailing nul-terminator on the title when copying the text.