### PR TITLE
GHA: update the lint workflow to 5.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
     - uses: compnerd/gha-setup-swift@main
       with:
-        branch: swift-5.6-release
-        tag: 5.6-RELEASE
+        branch: swift-5.8-release
+        tag: 5.8-RELEASE
     - name: Install swift-format
       run: |
-        Install-Binary -Url "https://github.com/compnerd/swift-build/releases/download/swift-format-5.6-RELEASE/swift-format.msi" -Name "swift-format.msi" -ArgumentList ("-q")
+        Install-Binary -Url "https://github.com/compnerd/swift-build/releases/download/swift-format-5.8-RELEASE/swift-format.msi" -Name "swift-format.msi" -ArgumentList ("-q")
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Update the linting workflow to use the 5.8 release to gain the newer functionality and better stability.