### PR TITLE
Windows and Screens: trigger a `viewDidLoad` in `ViewController`

### DIFF
--- a/Sources/SwiftWin32/Windows and Screens/Window.swift
+++ b/Sources/SwiftWin32/Windows and Screens/Window.swift
@@ -150,6 +150,7 @@ public class Window: View {
   public var rootViewController: ViewController? {
     didSet {
       self.rootViewController?.view = self
+      self.rootViewController?.viewDidLoad()
 
       if let builder = _MenuBuilder(for: self) {
         self.rootViewController?.buildMenu(with: builder)


### PR DESCRIPTION
When the Window is assigned a `rootViewController`, we should trigger a `viewDidLoad` event.