### PR TITLE
SwiftWin32: add `Label.textAlignment` property

### DIFF
--- a/Sources/SwiftWin32/CMakeLists.txt
+++ b/Sources/SwiftWin32/CMakeLists.txt
@@ -117,6 +117,7 @@ target_sources(SwiftWin32 PRIVATE
   "Views and Controls/Slider.swift"
   "Views and Controls/Stepper.swift"
   "Views and Controls/Switch.swift"
+  "Views and Controls/TextAlignment.swift"
   "Views and Controls/TextField.swift"
   "Views and Controls/TextView.swift"
   "Views and Controls/View.swift"

--- a/Sources/SwiftWin32/Views and Controls/Label.swift
+++ b/Sources/SwiftWin32/Views and Controls/Label.swift
@@ -46,6 +46,37 @@ public class Label: Control {
     }
   }
 
+  public var textAlignment: TextAlignment {
+    get {
+      switch GWL_STYLE & SS_TYPEMASK {
+      case SS_CENTER:
+        return .center
+      case SS_RIGHT:
+        return .right
+      case SS_LEFTNOWORDWRAP, SS_LEFT:
+        return .left
+      default:
+        fatalError("unknown alignment for WC_STATIC")
+      }
+    }
+
+    set {
+      var lAlignment = GWL_STYLE & ~SS_TYPEMASK
+      switch newValue {
+      case .left: lAlignment |= SS_LEFTNOWORDWRAP
+      case .right: lAlignment |= SS_RIGHT
+      case .center: lAlignment |= SS_CENTER
+      case .justified, .natural:
+        log.error("TextAlignment.\(newValue) is not supported")
+      }
+      GWL_STYLE = lAlignment
+      if !SetWindowPos(self.hWnd_, nil, 0, 0, 0, 0,
+                       UINT(SWP_NOACTIVATE | SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_DRAWFRAME)) {
+        log.warning("SetWindowPos: \(Error(win32: GetLastError()))")
+      }
+    }
+  }
+
   public override var frame: Rect {
     didSet {
       let size = self.frame.size

--- a/Sources/SwiftWin32/Views and Controls/TextAlignment.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextAlignment.swift
@@ -1,0 +1,16 @@
+// Copyright © 2023 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Constants that specify text alignment.
+public enum TextAlignment: Int {
+  /// Text uses the default alignment for the current localization of the app.
+  case natural
+  /// Text is left-aligned.
+  case left
+  /// Text is right-aligned.
+  case right
+  /// Text is center-aligned.
+  case center
+  /// Text is justified.
+  case justified
+}

--- a/Sources/SwiftWin32/Views and Controls/TextField.swift
+++ b/Sources/SwiftWin32/Views and Controls/TextField.swift
@@ -50,14 +50,6 @@ private let SwiftTextFieldProc: SUBCLASSPROC = { (hWnd, uMsg, wParam, lParam, uI
   return DefSubclassProc(hWnd, uMsg, wParam, lParam)
 }
 
-public enum TextAlignment: Int {
-  case natural
-  case left
-  case right
-  case center
-  case justified
-}
-
 public class TextField: Control {
   private static let `class`: WindowClass = WindowClass(named: MSFTEDIT_CLASS)
   private static let style: WindowStyle =

--- a/Tests/UICoreTests/LabelTests.swift
+++ b/Tests/UICoreTests/LabelTests.swift
@@ -1,0 +1,22 @@
+// Copyright © 2023 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import XCTest
+@testable import SwiftWin32
+
+final class LabelTests: XCTestCase {
+  func testAlignment() {
+    let label: Label = Label(frame: .zero)
+
+    // FIXME(compnerd) this should be `natural`
+    XCTAssertEqual(label.textAlignment, .left)
+
+    label.textAlignment = .right
+    XCTAssertEqual(label.textAlignment, .right)
+  }
+
+  static var allTests = [
+    ("testAlignment", testAlignment),
+  ]
+}
+


### PR DESCRIPTION
Add the missing `textAlignment` property for the partial cases which are trivial to map.  This allows for better control over the rendering of the text.