### PR TITLE
manifest: use a stable release for swift-log

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,8 @@ let SwiftWin32 = Package(
     .executable(name: "Calculator", targets: ["Calculator"]),
   ],
   dependencies: [
-    // NOTE(compnerd) require main as no current release has support for the
-    // new CRT module.
-    .package(url: "https://github.com/apple/swift-log.git", branch: "main"),
+    .package(url: "https://github.com/apple/swift-log.git",
+             .uptoNextMajor(from: "1.4.3")),
     .package(url: "https://github.com/apple/swift-collections.git",
              .upToNextMinor(from: "1.0.0")),
     .package(url: "https://github.com/compnerd/cassowary.git", branch: "main"),

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let SwiftWin32 = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-log.git",
-             .uptoNextMajor(from: "1.4.3")),
+             .upToNextMajor(from: "1.4.3")),
     .package(url: "https://github.com/apple/swift-collections.git",
              .upToNextMinor(from: "1.0.0")),
     .package(url: "https://github.com/compnerd/cassowary.git", branch: "main"),

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -12,7 +12,7 @@ let SwiftWin32 = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-log.git",
-             .uptoNextMajor(from: "1.4.3")),
+             .upToNextMajor(from: "1.4.3")),
     .package(url: "https://github.com/apple/swift-collections.git",
              .upToNextMinor(from: "1.0.0")),
     .package(url: "https://github.com/compnerd/cassowary.git", .branch("main")),

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -11,9 +11,8 @@ let SwiftWin32 = Package(
     .executable(name: "Calculator", targets: ["Calculator"]),
   ],
   dependencies: [
-    // NOTE(compnerd) require main as no current release has support for the
-    // new CRT module.
-    .package(url: "https://github.com/apple/swift-log.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-log.git",
+             .uptoNextMajor(from: "1.4.3")),
     .package(url: "https://github.com/apple/swift-collections.git",
              .upToNextMinor(from: "1.0.0")),
     .package(url: "https://github.com/compnerd/cassowary.git", .branch("main")),


### PR DESCRIPTION
There is the 1.4.3 release of swift-log that contains the required changes. Update the manifest to try to use a stable release instead of main.