### PR TITLE
SwiftWin32: silence warning on recent development compilers

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -38,9 +38,6 @@ let SwiftWin32: Package =
                     ],
                     path: "Sources/SwiftWin32",
                     exclude: ["CoreAnimation", "CMakeLists.txt"],
-                    swiftSettings: [
-                      .enableExperimentalFeature("AccessLevelOnImport"),
-                    ],
                     linkerSettings: [
                       .linkedLibrary("User32"),
                       .linkedLibrary("ComCtl32"),

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,1 @@
+Package@swift-5.7.swift

--- a/Sources/SwiftWin32/Platform/Win32+Menu.swift
+++ b/Sources/SwiftWin32/Platform/Win32+Menu.swift
@@ -3,8 +3,12 @@
 
 import WinSDK
 
+#if swift(>=5.9)
+internal import OrderedCollections
+#else
 @_implementationOnly
 import OrderedCollections
+#endif
 
 internal final class _MenuBuilder: MenuSystem {
   internal private(set) var hMenu: MenuHandle

--- a/Sources/SwiftWin32/Support/Logging.swift
+++ b/Sources/SwiftWin32/Support/Logging.swift
@@ -1,7 +1,11 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
+#if swift(>=5.9)
+internal import Logging
+#else
 @_implementationOnly
 import Logging
+#endif
 
 internal let log: Logger = Logger(label: "org.compnerd.swift-win32")


### PR DESCRIPTION
Use the newly minted support for access control on imports (SE-0409) to clean up some newer warnings.