### PR TITLE
SwiftWin32: compensate for `GetComputerNameW`'s disregard of the null terminator

### DIFF
--- a/Sources/SwiftWin32/App and Environment/Device.swift
+++ b/Sources/SwiftWin32/App and Environment/Device.swift
@@ -15,7 +15,7 @@ public struct Device {
     let value: [WCHAR] =
         Array<WCHAR>(unsafeUninitializedCapacity: Int(MAX_COMPUTERNAME_LENGTH) + 1) {
       var nSize: DWORD = DWORD($0.count)
-      $1 = GetComputerNameW($0.baseAddress!, &nSize) ? Int(nSize) : 0
+      $1 = GetComputerNameW($0.baseAddress!, &nSize) ? Int(nSize) + 1 : 0
     }
     return String(decodingCString: value, as: UTF16.self)
   }


### PR DESCRIPTION
Hi @compnerd, before I jump to the PR I just wanted to say thanks for all the work you're putting into this project 😀

### Issue

`GetComputerNameW` disregards the null terminator when returning the size of the buffer. This leads to the following error when using `Device.name`:

`Swift/CString.swift:284: Fatal error: input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated`

### Solution

Compensated the buffer size to account for the null terminator.