### PR TITLE
Support: remove extension that is unused

### DIFF
--- a/Sources/SwiftWin32/Support/String+UIExtensions.swift
+++ b/Sources/SwiftWin32/Support/String+UIExtensions.swift
@@ -2,14 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 extension String {
-  internal init(from utf16: [UInt16]) {
-    self = utf16.withUnsafeBufferPointer {
-      String(decodingCString: $0.baseAddress!, as: UTF16.self)
-    }
-  }
-}
-
-extension String {
   public var wide: [UInt16] {
     return Array<UInt16>(from: self)
   }


### PR DESCRIPTION
Clean up the unused extension for `String` as work towards removing the UTF16 string extensions.