### PR TITLE
SwiftWin32: enable tab control in ComCtl32

### DIFF
--- a/Sources/SwiftWin32/App and Environment/ApplicationMain.swift
+++ b/Sources/SwiftWin32/App and Environment/ApplicationMain.swift
@@ -98,6 +98,7 @@ public func ApplicationMain(_ argc: Int32,
                    | DWORD(ICC_NATIVEFNTCTL_CLASS)
                    | DWORD(ICC_PROGRESS_CLASS)
                    | DWORD(ICC_STANDARD_CLASSES)
+                   | DWORD(ICC_TAB_CLASSES)
   var ICCE: INITCOMMONCONTROLSEX =
       INITCOMMONCONTROLSEX(dwSize: DWORD(MemoryLayout<INITCOMMONCONTROLSEX>.size),
                            dwICC: dwICC)

--- a/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
+++ b/Sources/SwiftWin32/Support/WinSDK+Extensions.swift
@@ -148,6 +148,21 @@ internal var QS_ALLINPUT: DWORD {
 }
 
 @_transparent
+internal var TCS_BOTTOM: DWORD {
+  DWORD(WinSDK.TCS_BOTTOM)
+}
+
+@_transparent
+internal var TCS_FIXEDWIDTH: DWORD {
+  DWORD(WinSDK.TCS_FIXEDWIDTH)
+}
+
+@_transparent
+internal var TCS_FLATBUTTONS: DWORD {
+  DWORD(WinSDK.TCS_FLATBUTTONS)
+}
+
+@_transparent
 internal var WS_BORDER: DWORD {
   DWORD(WinSDK.WS_BORDER)
 }


### PR DESCRIPTION
Enable the tab control behaviours for Common Controls to allow us to build out some of the tab view handling.