### PR TITLE
Remove symlinks

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,1 +1,0 @@
-Package@swift-5.4.swift

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -1,1 +1,0 @@
-Package@swift-5.4.swift

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,1 +1,0 @@
-Package@swift-5.7.swift


### PR DESCRIPTION
Removed `Package.swift` symlinks as they break SwiftPM and are not needed, as it already fails back to the latest version supported by the local Swift package tools.
Closes #781 