### PR TITLE
Update lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,11 +14,8 @@ jobs:
     steps:
     - uses: compnerd/gha-setup-swift@main
       with:
-        branch: swift-5.8-release
-        tag: 5.8-RELEASE
-    - name: Install swift-format
-      run: |
-        Install-Binary -Url "https://github.com/compnerd/swift-build/releases/download/swift-format-5.8-RELEASE/swift-format.msi" -Name "swift-format.msi" -ArgumentList ("-q")
+        swift-build: 6.2-RELEASE
+        swift-version: swift-6.2-release
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Update to 6.2.0 release, remove installation as swift-format is now shipped as part of the toolchain.